### PR TITLE
Correctly use import of addons product

### DIFF
--- a/barcode_link/__init__.py
+++ b/barcode_link/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,6 +17,5 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import barcode_link

--- a/barcode_link/__openerp__.py
+++ b/barcode_link/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 {
     "name": "Barcode link Module",
@@ -44,5 +44,3 @@ And link the barcode with a product.
     'installable': True,
     'active': False,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/barcode_link/barcode_link.py
+++ b/barcode_link/barcode_link.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 from openerp.osv import fields, orm
 
@@ -26,7 +26,8 @@ class tr_barcode(orm.Model):
 
     _inherit = 'tr.barcode'
 
-    def _name_get_barcode(self, cr, uid, ids, field_name, arg=None, context=None):
+    def _name_get_barcode(self, cr, uid, ids, field_name, arg=None,
+                          context=None):
         if not len(ids):
             return []
         reads = self.browse(cr, uid, ids, context=context)
@@ -45,5 +46,3 @@ class tr_barcode(orm.Model):
                                 size=100,
                                 string="Link"),
     }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/product_multi_ean/product_ean.py
+++ b/product_multi_ean/product_ean.py
@@ -104,7 +104,8 @@ class ProductProduct(orm.Model):
             res.add(ean.product_id.id)
         return list(res)
 
-    def _write_ean(self, cr, uid, product_id, _name, value, _arg, context=None):
+    def _write_ean(self, cr, uid, product_id, _name, value, _arg,
+                   context=None):
         product = self.browse(cr, uid, product_id, context=context)
         if value and value not in [ean.name for ean in product.ean13_ids]:
             self.pool.get('product.ean13').create(
@@ -124,7 +125,9 @@ class ProductProduct(orm.Model):
             readonly=True,
             store={
                 'product.product':
-                    (lambda self, cr, uid, ids, c=None: ids, ['ean13_ids'], 10),
+                    (lambda self, cr, uid, ids, c=None: ids,
+                     ['ean13_ids'],
+                     10),
                 'product.ean13':
                     (_get_ean, [], 10)})}
 

--- a/product_multi_ean/product_ean.py
+++ b/product_multi_ean/product_ean.py
@@ -41,7 +41,7 @@ class ProductEan13(orm.Model):
     def _check_ean_key(self, cr, uid, ids):
         res = False
         for ean in self.browse(cr, uid, ids):
-            res = addon_product.product.check_ean(ean.name)
+            res = addon_product.check_ean(ean.name)
             if not res:
                 return res
         return res

--- a/tr_barcode/__init__.py
+++ b/tr_barcode/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Tech-Receptives Solutions Pvt. Ltd.
-#    Copyright (C) 2004-TODAY Tech-Receptives(<http://www.tech-receptives.com>).
+#    Copyright (C) 2004-TODAY Tech-Receptives <http://www.tech-receptives.com>.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -18,7 +18,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
 from . import tr_barcode
 from . import res_config
 from . import wizard

--- a/tr_barcode/__openerp__.py
+++ b/tr_barcode/__openerp__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Tech-Receptives Solutions Pvt. Ltd.
-#    Copyright (C) 2004-TODAY Tech-Receptives(<http://www.tech-receptives.com>).
+#    Copyright (C) 2004-TODAY Tech-Receptives<http://www.tech-receptives.com>.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -47,4 +47,3 @@ This module adds the menu Barcode used to generate and configuration barcodes.
     'installable': True,
     'active': False,
 }
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode/res_config.py
+++ b/tr_barcode/res_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 import copy
 
 from openerp.osv import fields, orm
@@ -32,10 +31,11 @@ class ir_model(orm.Model):
                            help='If checked, by default the barcode '
                            'configuration will get this module '
                            'in the list'),
-        }
+    }
+
     _defaults = {
         'barcode_model': False,
-        }
+    }
 
 
 class tr_barcode_settings(orm.TransientModel):
@@ -52,10 +52,11 @@ class tr_barcode_settings(orm.TransientModel):
             fields.many2many('ir.model',
                              'tr_barcode_settings_mode_rel',
                              'tr_id', 'model_id', 'Models'),
-        }
+    }
+
     _defaults = {
         'models_ids': _get_default_barcode_models,
-        }
+    }
 
     def update_field(self, cr, uid, vals, context=None):
         # Init
@@ -71,9 +72,11 @@ class tr_barcode_settings(orm.TransientModel):
         elif vals['models_ids'][0] and vals['models_ids'][0][2]:
             model_ids = vals['models_ids'][0][2]
         # Unlink Previous Entries #
-        unlink_ids = action_obj.search(cr,  uid,
-                                       [('res_model', '=', 'tr.barcode.wizard')],
-                                       context=context)
+        unlink_ids = action_obj.search(
+            cr,  uid,
+            [('res_model', '=', 'tr.barcode.wizard')],
+            context=context
+        )
         for unlink_id in unlink_ids:
             action_obj.unlink(cr, uid, unlink_id)
             domain = [('value', '=', "ir.actions.act_window,%s" % unlink_id)]
@@ -110,7 +113,9 @@ class tr_barcode_settings(orm.TransientModel):
     def create(self, cr, uid, vals, context=None):
         """ create method """
         vals2 = copy.deepcopy(vals)
-        result = super(tr_barcode_settings, self).create(cr, uid, vals2, context=context)
+        result = super(tr_barcode_settings, self).create(
+            cr, uid, vals2, context=context
+        )
         # Fields Process #
         self.update_field(cr, uid, vals, context=context)
         return result
@@ -121,10 +126,8 @@ class tr_barcode_settings(orm.TransientModel):
             context = {}
         # install method
         for vals in self.read(cr, uid, ids, context=context):
-            _result = self.update_field(cr, uid, vals, context=context)
+            self.update_field(cr, uid, vals, context=context)
         return {
             'type': 'ir.actions.client',
             'tag': 'reload',
-            }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+        }

--- a/tr_barcode/tr_barcode.py
+++ b/tr_barcode/tr_barcode.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Tech-Receptives Solutions Pvt. Ltd.
-#    Copyright (C) 2004-TODAY Tech-Receptives(<http://www.tech-receptives.com>).
+#    Copyright (C) 2004-TODAY Tech-Receptives <http://www.tech-receptives.com>.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -90,7 +90,9 @@ class tr_barcode(orm.Model):
 #        options['isoScale'] = 1
         if code not in ('QR', 'qrcode'):
             try:
-                ret_val = createBarcodeDrawing(code, value=str(value), **options)
+                ret_val = createBarcodeDrawing(code,
+                                               value=str(value),
+                                               **options)
             except Exception, e:
                 raise osv.except_osv('Error', e)
             image_data = ret_val.asString('png')

--- a/tr_barcode/tr_barcode_installer.py
+++ b/tr_barcode/tr_barcode_installer.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Tech-Receptives Solutions Pvt. Ltd.
-#    Copyright (C) 2004-TODAY Tech-Receptives(<http://www.tech-receptives.com>).
+#    Copyright (C) 2004-TODAY Tech-Receptives <http://www.tech-receptives.com>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -47,9 +47,11 @@ class tr_barcode_installer(orm.TransientModel):
         act_window = self.pool.get('ir.actions.act_window')
         ir_value = self.pool.get('ir.values')
         ir_model = self.pool.get('ir.model')
-        unlink_ids = act_window.search(cr,
-                                       uid,
-                                       [('res_model', '=', 'tr.barcode.wizard')])
+        unlink_ids = act_window.search(
+            cr,
+            uid,
+            [('res_model', '=', 'tr.barcode.wizard')]
+        )
 
         for unlink_id in unlink_ids:
 

--- a/tr_barcode/wizard/__init__.py
+++ b/tr_barcode/wizard/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Tech-Receptives Solutions Pvt. Ltd.
-#    Copyright (C) 2004-TODAY Tech-Receptives(<http://www.tech-receptives.com>).
+#    Copyright (C) 2004-TODAY Tech-Receptives <http://www.tech-receptives.com>.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/tr_barcode/wizard/tr_barcode_wizard.py
+++ b/tr_barcode/wizard/tr_barcode_wizard.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Tech-Receptives Solutions Pvt. Ltd.
-#    Copyright (C) 2004-TODAY Tech-Receptives(<http://www.tech-receptives.com>).
+#    Copyright (C) 2004-TODAY Tech-Receptives <http://www.tech-receptives.com>.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -46,9 +46,11 @@ class tr_barcode_wizard(orm.TransientModel):
         if not context.get('active_model', False) \
            or not context.get('active_id', False):
             return False
-        vals = self.pool.get(context['active_model']).browse(cr, uid,
-                                                             context['active_id'],
-                                                             context=context)
+        vals = self.pool.get(context['active_model']).browse(
+            cr, uid,
+            context['active_id'],
+            context=context
+        )
         return vals and vals.x_barcode_id and vals.x_barcode_id.code or False
 
     _columns = {
@@ -100,21 +102,27 @@ class tr_barcode_wizard(orm.TransientModel):
         barcode_pool = self.pool.get('tr.barcode')
         for self_obj in self.browse(cr, uid, ids, context=context):
             if not self_obj.barcode:
-                raise osv.except_osv(_('Error'),
-                                     _('Please specify code to generate Barcode !'))
+                raise osv.except_osv(
+                    _('Error'),
+                    _('Please specify code to generate Barcode !')
+                )
             if not self_obj.barcode_type:
                 raise osv.except_osv(_('Error'), _('Please Select Type !'))
-            cr_id = barcode_pool.create(cr, uid, {
-                'code': self_obj.barcode,
-                'barcode_type': self_obj.barcode_type,
-                'width': self_obj.width,
-                'height': self_obj.height,
-                'hr_form': self_obj.hr_form,
-                'res_model':
-                    context.get('src_model', False) or
-                    context['active_model'],
-                'res_id': context['active_id'],
-                })
+            cr_id = barcode_pool.create(
+                cr,
+                uid,
+                {
+                    'code': self_obj.barcode,
+                    'barcode_type': self_obj.barcode_type,
+                    'width': self_obj.width,
+                    'height': self_obj.height,
+                    'hr_form': self_obj.hr_form,
+                    'res_model': (context.get('src_model', False) or
+                                  context['active_model']),
+                    'res_id': context['active_id']
+                }
+            )
+
             barcode_pool.generate_image(cr, uid, [cr_id], context=context)
             return {
                 'res_id': cr_id,
@@ -124,6 +132,4 @@ class tr_barcode_wizard(orm.TransientModel):
                 'res_model': 'tr.barcode',
                 'view_id': False,
                 'type': 'ir.actions.act_window',
-                }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+            }

--- a/tr_barcode_config/__init__.py
+++ b/tr_barcode_config/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,6 +17,5 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import barcode_config

--- a/tr_barcode_config/__openerp__.py
+++ b/tr_barcode_config/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 {
     "name": "Barcode configuration Module",
     "version": "1.1.1",

--- a/tr_barcode_config/barcode/__init__.py
+++ b/tr_barcode_config/barcode/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,6 +17,5 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import barcode_osv

--- a/tr_barcode_config/barcode/barcode_osv.py
+++ b/tr_barcode_config/barcode/barcode_osv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 from openerp.osv import orm
 from openerp import pooler
@@ -84,9 +84,13 @@ def create_barcode(cr, uid, id, vals, model, context=None):
             }
             if not barcode_vals.get('code', False):
                 read_value = pool.get(model).read(cr, uid, id)
-                barcode_vals['code'] = read_value.get(barcode_config.field.name, False)
+                barcode_vals['code'] = read_value.get(
+                    barcode_config.field.name,
+                    False
+                )
             barcode_obj = pool.get('tr.barcode')
-            barcode_id = barcode_obj.create(cr, uid, barcode_vals, context=context)
+            barcode_id = barcode_obj.create(cr, uid, barcode_vals,
+                                            context=context)
             barcode_obj.generate_image(cr, uid, [barcode_id], context=context)
     else:
         write_barcode(cr, uid, [barcode_id], vals, model, context=context)
@@ -115,13 +119,15 @@ class barcode_osv(orm.Model):
         obj = self.browse(cr, uid, res, context=context)
         if hasattr(obj, 'x_barcode_id'):
             if not obj.x_barcode_id:
-                barcode_id = create_barcode(cr, uid, res, vals, self._name, context=context)
+                barcode_id = create_barcode(cr, uid, res, vals,
+                                            self._name, context=context)
             else:
                 barcode_id = obj.x_barcode_id.id
         # end modification
 
             if barcode_id:
-                query = "UPDATE %s SET x_barcode_id = %%s WHERE id = %%s" % self._table
+                query = ("UPDATE %s SET x_barcode_id = %%s "
+                         "WHERE id = %%s") % self._table
                 cr.execute(query, (barcode_id, res))
         return res
 
@@ -136,12 +142,14 @@ class barcode_osv(orm.Model):
             if not hasattr(obj, 'x_barcode_id'):
                 break  # the module is not fully configured, quick exit
             if not obj.x_barcode_id:
-                barcode_ids = barcode_obj.search(cr, uid,
-                                                 [('res_model', '=', self._name),
-                                                  ('res_id', '=', obj.id)
-                                                  ],
-                                                 limit=1,
-                                                 context=context)
+                barcode_ids = barcode_obj.search(
+                    cr,
+                    uid,
+                    [('res_model', '=', self._name),
+                     ('res_id', '=', obj.id)],
+                    limit=1,
+                    context=context
+                )
                 if barcode_ids:
                     write_barcode(cr, uid,
                                   [barcode_ids[0]],
@@ -163,6 +171,5 @@ class barcode_osv(orm.Model):
                               vals,
                               self._name,
                               context=context)
-        return super(orm.Model, self).write(cr, uid, ids, vals, context=context)
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+        return super(orm.Model, self).write(cr, uid, ids, vals,
+                                            context=context)

--- a/tr_barcode_config/barcode_config.py
+++ b/tr_barcode_config/barcode_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 import logging
 
 from openerp.osv import fields, orm
@@ -53,11 +53,9 @@ class tr_barcode_config(orm.Model):
             fields.boolean("Human Readable",
                            help="To generate Barcode In Human readable form"),
         'barcode_type': fields.selection(_get_code, 'Type', required=True),
-        }
+    }
     _sql_constraints = [
         ('res_model_uniq',
          'unique(res_model)',
          'You can have only one config by model !'),
-        ]
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+    ]

--- a/tr_barcode_field/__init__.py
+++ b/tr_barcode_field/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,6 +17,5 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import barcode_field

--- a/tr_barcode_field/__openerp__.py
+++ b/tr_barcode_field/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 {
     "name": "Barcode field Module",
@@ -41,5 +41,3 @@ This module adds a field to make a link between the product and the barcode.
     'installable': True,
     'active': False,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_field/barcode_field.py
+++ b/tr_barcode_field/barcode_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2011 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.osv import orm
 
 
@@ -41,8 +40,7 @@ class tr_barcode_installer(orm.TransientModel):
                                     context=context)
         for model in read_datas:
             domain = [('name', '=', 'x_barcode_id'),
-                      ('model', '=', model['model']),
-                      ]
+                      ('model', '=', model['model'])]
             field_ids = field_obj.search(cr, uid, domain)
             if not field_ids:
                 data_field = {'model': model['model'],
@@ -53,11 +51,9 @@ class tr_barcode_installer(orm.TransientModel):
                               'state': 'manual',
                               'ttype': 'many2one',
                               'selection': False,
-                              'on_delete': 'set null',
-                              }
+                              'on_delete': 'set null'}
                 field_obj.create(cr, uid, data_field, context=context)
-        return {'type': 'ir.actions.client',
-                'tag': 'reload',
-                }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'reload',
+        }

--- a/tr_barcode_on_picking/__init__.py
+++ b/tr_barcode_on_picking/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import picking
 from . import res_config

--- a/tr_barcode_on_picking/__openerp__.py
+++ b/tr_barcode_on_picking/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 {
     "name": "Barcode for pickings",
@@ -46,5 +46,3 @@ generate the barcode.
     "active": False,
     "installable": True,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_picking/picking.py
+++ b/tr_barcode_on_picking/picking.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.addons.tr_barcode_config.barcode import barcode_osv
 
 

--- a/tr_barcode_on_picking/res_config.py
+++ b/tr_barcode_on_picking/res_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 from openerp.osv import fields, orm
 from openerp.addons.tr_barcode.tr_barcode import _get_code
@@ -39,49 +39,66 @@ class tr_barcode_settings(orm.TransientModel):
         return res and res[0] or False
 
     _columns = {
-        'picking_config_id': fields.many2one('tr.barcode.config',
-                                             'Picking Config'),
-        'picking_model_id': fields.related('picking_config_id',
-                                           'res_model',
-                                           type='many2one',
-                                           relation="ir.model",
-                                           string="Model"),
-        'picking_field_id': fields.related('picking_config_id',
-                                           'field',
-                                           type='many2one',
-                                           relation="ir.model.fields",
-                                           string="Field"),
-        'picking_width': fields.related('picking_config_id',
-                                        'width',
-                                        type='integer',
-                                        string="Width",
-                                        help="Leave Blank or 0(ZERO) for default size"),
-        'picking_height': fields.related('picking_config_id',
-                                         'height',
-                                         type='integer',
-                                         string="Height",
-                                         help="Leave Blank or 0(ZERO) for default size"),
-        'picking_hr_form': fields.related('picking_config_id',
-                                          'hr_form',
-                                          type='boolean',
-                                          string="Human Readable",
-                                          help="To generate Barcode In Human readable form"),
-        'picking_barcode_type': fields.related('picking_config_id',
-                                               'barcode_type',
-                                               type='selection',
-                                               selection=_get_code,
-                                               string="Field"),
-        }
+        'picking_config_id': fields.many2one(
+            'tr.barcode.config',
+            'Picking Config'
+        ),
+        'picking_model_id': fields.related(
+            'picking_config_id',
+            'res_model',
+            type='many2one',
+            relation="ir.model",
+            string="Model"
+        ),
+        'picking_field_id': fields.related(
+            'picking_config_id',
+            'field',
+            type='many2one',
+            relation="ir.model.fields",
+            string="Field"
+        ),
+        'picking_width': fields.related(
+            'picking_config_id',
+            'width',
+            type='integer',
+            string="Width",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'picking_height': fields.related(
+            'picking_config_id',
+            'height',
+            type='integer',
+            string="Height",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'picking_hr_form': fields.related(
+            'picking_config_id',
+            'hr_form',
+            type='boolean',
+            string="Human Readable",
+            help="To generate Barcode In Human readable form"
+        ),
+        'picking_barcode_type': fields.related(
+            'picking_config_id',
+            'barcode_type',
+            type='selection',
+            selection=_get_code,
+            string="Field"
+        ),
+    }
     _defaults = {
         'picking_config_id': _get_default_picking_config_id,
-        }
+    }
 
-    def onchange_picking_config_id(self, cr, uid, _ids, picking_config_id, context=None):
+    def onchange_picking_config_id(self, cr, uid, _ids, picking_config_id,
+                                   context=None):
         values = {}
         if picking_config_id:
-            picking_config = self.pool.get('tr.barcode.config').browse(cr, uid,
-                                                                       picking_config_id,
-                                                                       context=context)
+            picking_config = self.pool.get('tr.barcode.config').browse(
+                cr, uid,
+                picking_config_id,
+                context=context
+            )
             values.update({
                 'picking_model_id':
                     picking_config.res_model.id
@@ -95,5 +112,3 @@ class tr_barcode_settings(orm.TransientModel):
                 'picking_barcode_type': picking_config.barcode_type or False,
             })
         return {'value': values}
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_prodlots/__init__.py
+++ b/tr_barcode_on_prodlots/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import prodlot
 from . import res_config

--- a/tr_barcode_on_prodlots/__openerp__.py
+++ b/tr_barcode_on_prodlots/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 {
     "name": "Barcode for production lots",
@@ -46,5 +46,3 @@ generate the barcode.
     "active": False,
     "installable": True,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_prodlots/prodlot.py
+++ b/tr_barcode_on_prodlots/prodlot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,12 +17,9 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.addons.tr_barcode_config.barcode import barcode_osv
 
 
 class stock_production_lot(barcode_osv.barcode_osv):
     _inherit = 'stock.production.lot'
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_prodlots/res_config.py
+++ b/tr_barcode_on_prodlots/res_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.osv import fields, orm
 from openerp.addons.tr_barcode.tr_barcode import _get_code
 
@@ -29,9 +28,11 @@ class tr_barcode_settings(orm.TransientModel):
     def _get_default_prodlot_config_id(self, cr, uid, context=None):
         config_obj = self.pool.get('tr.barcode.config')
         md_obj = self.pool.get('ir.model.data')
-        model_id, res_id = md_obj.get_object_reference(cr, uid,
-                                                       'stock',
-                                                       'model_stock_production_lot')
+        model_id, res_id = md_obj.get_object_reference(
+            cr, uid,
+            'stock',
+            'model_stock_production_lot'
+        )
         res = config_obj.search(cr, uid,
                                 [('res_model', '=', res_id)],
                                 limit=1,
@@ -39,36 +40,51 @@ class tr_barcode_settings(orm.TransientModel):
         return res and res[0] or False
 
     _columns = {
-        'prodlot_config_id': fields.many2one('tr.barcode.config',
-                                             'Production lot Config'),
-        'prodlot_model_id': fields.related('prodlot_config_id', 'res_model',
-                                           type='many2one',
-                                           relation="ir.model",
-                                           string="Model"),
-        'prodlot_field_id': fields.related('prodlot_config_id', 'field',
-                                           type='many2one',
-                                           relation="ir.model.fields",
-                                           string="Field"),
-        'prodlot_width': fields.related('prodlot_config_id', 'width',
-                                        type='integer',
-                                        string="Width",
-                                        help="Leave Blank or 0(ZERO) for default size"),
-        'prodlot_height': fields.related('prodlot_config_id', 'height',
-                                         type='integer',
-                                         string="Height",
-                                         help="Leave Blank or 0(ZERO) for default size"),
-        'prodlot_hr_form': fields.related('prodlot_config_id', 'hr_form',
-                                          type='boolean',
-                                          string="Human Readable",
-                                          help="To generate Barcode In Human readable form"),
-        'prodlot_barcode_type': fields.related('prodlot_config_id', 'barcode_type',
-                                               type='selection',
-                                               selection=_get_code,
-                                               string="Field"),
-        }
+        'prodlot_config_id': fields.many2one(
+            'tr.barcode.config',
+            'Production lot Config'
+        ),
+        'prodlot_model_id': fields.related(
+            'prodlot_config_id', 'res_model',
+            type='many2one',
+            relation="ir.model",
+            string="Model"
+        ),
+        'prodlot_field_id': fields.related(
+            'prodlot_config_id', 'field',
+            type='many2one',
+            relation="ir.model.fields",
+            string="Field"
+        ),
+        'prodlot_width': fields.related(
+            'prodlot_config_id', 'width',
+            type='integer',
+            string="Width",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'prodlot_height': fields.related(
+            'prodlot_config_id', 'height',
+            type='integer',
+            string="Height",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'prodlot_hr_form': fields.related(
+            'prodlot_config_id', 'hr_form',
+            type='boolean',
+            string="Human Readable",
+            help="To generate Barcode In Human readable form"
+        ),
+        'prodlot_barcode_type': fields.related(
+            'prodlot_config_id', 'barcode_type',
+            type='selection',
+            selection=_get_code,
+            string="Field"
+        ),
+    }
+
     _defaults = {
         'prodlot_config_id': _get_default_prodlot_config_id,
-        }
+    }
 
     def onchange_prodlot_config_id(self, cr, uid, ids,
                                    prodlot_config_id, context=None):
@@ -93,5 +109,3 @@ class tr_barcode_settings(orm.TransientModel):
                 'prodlot_barcode_type': prodlot_config.barcode_type or False,
                 })
         return {'value': values}
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_product/__init__.py
+++ b/tr_barcode_on_product/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import product
 from . import res_config

--- a/tr_barcode_on_product/__openerp__.py
+++ b/tr_barcode_on_product/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 {
     "name": "Barcode for product",
@@ -46,5 +46,3 @@ generate the barcode.
     "active": False,
     "installable": True,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_product/product.py
+++ b/tr_barcode_on_product/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,12 +17,9 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.addons.tr_barcode_config.barcode import barcode_osv
 
 
 class product_product(barcode_osv.barcode_osv):
     _inherit = 'product.product'
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_product/res_config.py
+++ b/tr_barcode_on_product/res_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.osv import fields, orm
 from openerp.addons.tr_barcode.tr_barcode import _get_code
 
@@ -29,43 +28,71 @@ class tr_barcode_settings(orm.TransientModel):
     def _get_default_product_config_id(self, cr, uid, context=None):
         config_obj = self.pool.get('tr.barcode.config')
         md_obj = self.pool.get('ir.model.data')
-        model_id, res_id = md_obj.get_object_reference(cr, uid, 'product', 'model_product_product')
-        res = config_obj.search(cr, uid, [('res_model', '=', res_id)], limit=1, context=context)
+        model_id, res_id = md_obj.get_object_reference(
+            cr,
+            uid,
+            'product',
+            'model_product_product'
+        )
+        res = config_obj.search(
+            cr,
+            uid,
+            [('res_model', '=', res_id)],
+            limit=1,
+            context=context
+        )
         return res and res[0] or False
 
     _columns = {
-        'product_config_id': fields.many2one('tr.barcode.config',
-                                             'Production lot Config'),
-        'product_model_id': fields.related('product_config_id', 'res_model',
-                                           type='many2one',
-                                           relation="ir.model",
-                                           string="Model"),
-        'product_field_id': fields.related('product_config_id', 'field',
-                                           type='many2one',
-                                           relation="ir.model.fields",
-                                           string="Field"),
-        'product_width': fields.related('product_config_id', 'width',
-                                        type='integer',
-                                        string="Width",
-                                        help="Leave Blank or 0(ZERO) for default size"),
-        'product_height': fields.related('product_config_id', 'height',
-                                         type='integer',
-                                         string="Height",
-                                         help="Leave Blank or 0(ZERO) for default size"),
-        'product_hr_form': fields.related('product_config_id', 'hr_form',
-                                          type='boolean',
-                                          string="Human Readable",
-                                          help="To generate Barcode In Human readable form"),
-        'product_barcode_type': fields.related('product_config_id', 'barcode_type',
-                                               type='selection',
-                                               selection=_get_code,
-                                               string="Field"),
-        }
+        'product_config_id': fields.many2one(
+            'tr.barcode.config',
+            'Production lot Config'
+        ),
+        'product_model_id': fields.related(
+            'product_config_id', 'res_model',
+            type='many2one',
+            relation="ir.model",
+            string="Model"
+        ),
+        'product_field_id': fields.related(
+            'product_config_id', 'field',
+            type='many2one',
+            relation="ir.model.fields",
+            string="Field"
+        ),
+        'product_width': fields.related(
+            'product_config_id', 'width',
+            type='integer',
+            string="Width",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'product_height': fields.related(
+            'product_config_id', 'height',
+            type='integer',
+            string="Height",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'product_hr_form': fields.related(
+            'product_config_id', 'hr_form',
+            type='boolean',
+            string="Human Readable",
+            help="To generate Barcode In Human readable form"
+        ),
+        'product_barcode_type': fields.related(
+            'product_config_id',
+            'barcode_type',
+            type='selection',
+            selection=_get_code,
+            string="Field"
+        ),
+    }
+
     _defaults = {
         'product_config_id': _get_default_product_config_id,
-        }
+    }
 
-    def onchange_product_config_id(self, cr, uid, _ids, product_config_id, context=None):
+    def onchange_product_config_id(self, cr, uid, _ids,
+                                   product_config_id, context=None):
         values = {}
         if product_config_id:
             config_obj = self.pool.get('tr.barcode.config')
@@ -82,8 +109,6 @@ class tr_barcode_settings(orm.TransientModel):
                 'product_width': product_config.width or 0,
                 'product_height': product_config.height or 0,
                 'product_hr_form': product_config.hr_form or False,
-                'product_barcode_type': product_config.barcode_type or False,
-                })
-        return {'value': values}
+                'product_barcode_type': product_config.barcode_type or False})
 
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+        return {'value': values}

--- a/tr_barcode_on_tracking/__init__.py
+++ b/tr_barcode_on_tracking/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,6 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from . import tracking
 from . import res_config

--- a/tr_barcode_on_tracking/__openerp__.py
+++ b/tr_barcode_on_tracking/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,7 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 {
     "name": "Barcode for tracking",
@@ -46,5 +46,3 @@ generate the barcode.
     "active": False,
     "installable": True,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/tr_barcode_on_tracking/res_config.py
+++ b/tr_barcode_on_tracking/res_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,8 +17,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
-
+###############################################################################
 from openerp.osv import fields, orm
 from openerp.addons.tr_barcode.tr_barcode import _get_code
 
@@ -29,43 +28,63 @@ class tr_barcode_settings(orm.TransientModel):
     def _get_default_tracking_config_id(self, cr, uid, context=None):
         config_obj = self.pool.get('tr.barcode.config')
         md_obj = self.pool.get('ir.model.data')
-        model_id, res_id = md_obj.get_object_reference(cr, uid, 'stock', 'model_stock_tracking')
-        res = config_obj.search(cr, uid, [('res_model', '=', res_id)], limit=1, context=context)
+        model_id, res_id = md_obj.get_object_reference(cr, uid, 'stock',
+                                                       'model_stock_tracking')
+        res = config_obj.search(cr, uid,
+                                [('res_model', '=', res_id)],
+                                limit=1,
+                                context=context)
         return res and res[0] or False
 
     _columns = {
-        'tracking_config_id': fields.many2one('tr.barcode.config',
-                                              'Picking Config'),
-        'tracking_model_id': fields.related('tracking_config_id', 'res_model',
-                                            type='many2one',
-                                            relation="ir.model",
-                                            string="Model"),
-        'tracking_field_id': fields.related('tracking_config_id', 'field',
-                                            type='many2one',
-                                            relation="ir.model.fields",
-                                            string="Field"),
-        'tracking_width': fields.related('tracking_config_id', 'width',
-                                         type='integer',
-                                         string="Width",
-                                         help="Leave Blank or 0(ZERO) for default size"),
-        'tracking_height': fields.related('tracking_config_id', 'height',
-                                          type='integer',
-                                          string="Height",
-                                          help="Leave Blank or 0(ZERO) for default size"),
-        'tracking_hr_form': fields.related('tracking_config_id', 'hr_form',
-                                           type='boolean',
-                                           string="Human Readable",
-                                           help="To generate Barcode In Human readable form"),
-        'tracking_barcode_type': fields.related('tracking_config_id', 'barcode_type',
-                                                type='selection',
-                                                selection=_get_code,
-                                                string="Field"),
-        }
+        'tracking_config_id': fields.many2one(
+            'tr.barcode.config',
+            'Picking Config'
+        ),
+        'tracking_model_id': fields.related(
+            'tracking_config_id', 'res_model',
+            type='many2one',
+            relation="ir.model",
+            string="Model"
+        ),
+        'tracking_field_id': fields.related(
+            'tracking_config_id', 'field',
+            type='many2one',
+            relation="ir.model.fields",
+            string="Field"
+        ),
+        'tracking_width': fields.related(
+            'tracking_config_id', 'width',
+            type='integer',
+            string="Width",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'tracking_height': fields.related(
+            'tracking_config_id', 'height',
+            type='integer',
+            string="Height",
+            help="Leave Blank or 0(ZERO) for default size"
+        ),
+        'tracking_hr_form': fields.related(
+            'tracking_config_id', 'hr_form',
+            type='boolean',
+            string="Human Readable",
+            help="To generate Barcode In Human readable form"
+        ),
+        'tracking_barcode_type': fields.related(
+            'tracking_config_id', 'barcode_type',
+            type='selection',
+            selection=_get_code,
+            string="Field"
+        ),
+    }
+
     _defaults = {
         'tracking_config_id': _get_default_tracking_config_id,
-        }
+    }
 
-    def onchange_tracking_config_id(self, cr, uid, _ids, tracking_config_id, context=None):
+    def onchange_tracking_config_id(self, cr, uid, _ids, tracking_config_id,
+                                    context=None):
         values = {}
         if tracking_config_id:
             config_obj = self.pool.get('tr.barcode.config')
@@ -86,6 +105,5 @@ class tr_barcode_settings(orm.TransientModel):
                 'tracking_hr_form': tracking_config.hr_form or False,
                 'tracking_barcode_type': tracking_config.barcode_type or False,
                 })
-        return {'value': values}
 
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+        return {'value': values}

--- a/tr_barcode_on_tracking/tracking.py
+++ b/tr_barcode_on_tracking/tracking.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#################################################################################
+###############################################################################
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2012 Julius Network Solutions SARL <contact@julius.fr>
@@ -17,12 +17,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#################################################################################
+###############################################################################
 
 from openerp.addons.tr_barcode_config.barcode import barcode_osv
 
 
 class stock_tracking(barcode_osv.barcode_osv):
     _inherit = 'stock.tracking'
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
During the PEP8 validation, the import was renamed from 'product' to 'addon_product', but the call added a layer; this creates an issue "no module called 'product'" when the function _check_ean_key was called.
