### PR TITLE
8.0 add module stock_inventory_barcode

### DIFF
--- a/stock_inventory_barcode/README.rst
+++ b/stock_inventory_barcode/README.rst
@@ -1,0 +1,88 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Stock Inventory Barcode
+=======================
+
+The interface provided by Odoo in the official *stock* module to make an
+inventory has 2 limitations:
+
+* it is not easy/fast to use when you have several thousand products
+
+* you cannot use a barcode reader to scan the products
+
+This module provides a simple and easy-to-use interface to make an
+inventory with the help of a barcode reader. It is designed for the
+following use case:
+
+* no tracking via Serial Numbers
+
+* the stock location of the inventory doesn't have children locations.
+
+Usage
+=====
+
+On the form view of an inventory, once the inventory has been started
+(State = *In Progress*), you will see a button *Start Barcode
+Interface*. It will open a pop-up window that allows the user to easily
+enter the inventory quantity (or update the inventory quantity, in case
+the product is found a second time at a different place during the
+inventory).
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/150/8.0
+
+Known issues / Roadmap
+======================
+
+* No tracking via Serial Number (I tried to implement it, but it makes
+  the interface more complex and/or slower to use: you can't get/create
+  the inventory line on the onchange of the Product field, you need to
+  the Serial Number to get/create the inventory line... but you also need
+  to handle the case of products that are not tracked by Serial Number,
+  etc...). I have tought in depth about it, and I think that it's better
+  to leave support for Serial Number outside of this module, to keep it
+  simple and easy-to-use for users that don't do any tracking via Serial
+  Numbers (which is the case of the point of sales).
+
+* Doesn't support inventory on locations that have children locations.
+  It is easy to add support for this, but it adds one field in the wizard,
+  thus make it slower to use for the user.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-barcode/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+stock-logistics-barcode/issues/new?body=module:%20
+stock_inventory_barcode%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_inventory_barcode/__init__.py
+++ b/stock_inventory_barcode/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import wizard

--- a/stock_inventory_barcode/__openerp__.py
+++ b/stock_inventory_barcode/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Stock Inventory Barcode module for Odoo
+#    Copyright (C) 2015 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Barcode Input for Inventories",
+    'version': "8.0.0.1.0",
+    'category': "Inventory, Logistic, Storage",
+    'author': 'Akretion,Odoo Community Association (OCA)',
+    'summary': "Add simple barcode interface on inventories",
+    'license': 'AGPL-3',
+    "description": """This module adds input fields to the inventory view
+which allow to add products to the inventory list by a barcode scanner.
+For this the barcode scanner must be configured as a keyboard that appends
+a LF after the scan and the cursor must be in the barcode field.
+
+The barcode input functionality is provided by a abstract model that can also
+be used with other models.
+""",
+    'depends': ['stock'],
+    'data': [
+        'wizard/stock_inventory_barcode_view.xml',
+        'stock_view.xml',
+        ],
+    'installable': True,
+}

--- a/stock_inventory_barcode/stock_view.xml
+++ b/stock_inventory_barcode/stock_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+<record id="view_inventory_form" model="ir.ui.view">
+    <field name="name">stock.inventory.barcode.inventory.form</field>
+    <field name="model">stock.inventory</field>
+    <field name="inherit_id" ref="stock.view_inventory_form"/>
+    <field name="arch" type="xml">
+        <button name="action_cancel_inventory" position="after">
+            <button name="%(stock_inventory_barcode_action)d" type="action"
+                string="Start Barcode Interface" states="confirm"/>
+        </button>
+    </field>
+</record>
+
+</data>
+</openerp>

--- a/stock_inventory_barcode/wizard/__init__.py
+++ b/stock_inventory_barcode/wizard/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import stock_inventory_barcode

--- a/stock_inventory_barcode/wizard/stock_inventory_barcode.py
+++ b/stock_inventory_barcode/wizard/stock_inventory_barcode.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Stock Inventory Barcode module for Odoo
+#    Copyright (C) 2015 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api, _
+import openerp.addons.decimal_precision as dp
+from openerp.exceptions import Warning as UserError
+
+
+class StockInventoryBarcode(models.TransientModel):
+    _name = 'stock.inventory.barcode'
+    _description = 'Stock Inventory Barcode Wizard'
+
+    product_code = fields.Char(
+        string='EAN13 or Internal Reference',
+        help="This field is designed to be filled with a barcode reader")
+    product_id = fields.Many2one(
+        'product.product', string='Product', required=True)
+    theoretical_qty = fields.Float(
+        related='inventory_line_id.theoretical_qty', readonly=True)
+    product_qty = fields.Float(
+        string='Current Real Quantity',
+        related='inventory_line_id.product_qty', readonly=True)
+    change_qty = fields.Float(
+        string='Change Real Quantity',
+        digits=dp.get_precision('Product Unit of Measure'))
+    add_qty = fields.Float(
+        string='Add to Real Quantity',
+        digits=dp.get_precision('Product Unit of Measure'))
+    inventory_line_id = fields.Many2one(
+        'stock.inventory.line', string='Stock Inventory Line')
+
+    @api.onchange('product_code')
+    def product_code_change(self):
+        if self.product_code:
+            products = self.env['product.product'].search([
+                '|',
+                ('ean13', '=', self.product_code),
+                ('default_code', '=ilike', self.product_code)])
+            if len(products) == 1:
+                self.product_id = products[0]
+            elif len(products) > 1:
+                return {'warning': {
+                    'title': _('Error'),
+                    'message': _(
+                        'Several products have been found '
+                        'with this code as EAN13 or Internal Reference:\n %s'
+                        '\nYou should select the right product manually.'
+                        ) % '\n'.join([
+                            product.name_get()[0][1] for product in products
+                            ])}}
+            else:
+                return {'warning': {
+                    'title': _('Error'),
+                    'message': _(
+                        'No product found with this code as '
+                        'EAN13 nor Internal Reference. You should select '
+                        'the right product manually.')}}
+
+    @api.onchange('product_id')
+    def product_id_change(self):
+        assert self._context['active_model'] == 'stock.inventory',\
+            'wrong underlying model'
+        assert self._context['active_id'], 'Missing active_id in ctx'
+        if self.product_id:
+            silo = self.env['stock.inventory.line']
+            sio = self.env['stock.inventory']
+            inventory_id = self._context['active_id']
+            ilines = silo.search([
+                ('inventory_id', '=', inventory_id),
+                ('product_id', '=', self.product_id.id),
+                ])
+            if len(ilines) == 1:
+                self.inventory_line_id = ilines[0]
+                self.change_qty = ilines[0].product_qty
+            elif len(ilines) > 1:
+                return {'warning': {
+                    'title': _('Error'),
+                    'message': _(
+                        'Several inventory lines exists for this product. '
+                        'This scenario is not supported for the moment. '
+                        'It may be caused by the fact that you have '
+                        'sub-locations in the stock location of this '
+                        'inventory and this product is present in '
+                        'several sub-locations, or by the fact that you '
+                        'track Serial Numbers for this product.')}}
+            else:
+                inventory = sio.browse(inventory_id)
+                new_iline = silo.create({
+                    'inventory_id': inventory_id,
+                    'location_id': inventory.location_id.id,
+                    'product_id': self.product_id.id,
+                    'product_uom_id': self.product_id.uom_id.id,
+                    })
+                self.inventory_line_id = new_iline
+
+    @api.multi
+    def save(self):
+        self.ensure_one()
+        if not self.inventory_line_id:
+            raise UserError(_('No related inventory line'))
+        if self.add_qty:
+            self.inventory_line_id.product_qty += self.add_qty
+        elif self.change_qty != self.product_qty:
+            self.inventory_line_id.product_qty = self.change_qty
+        action = {
+            'name': _('Stock Inventory Barcode Wizard'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'stock.inventory.barcode',
+            'view_mode': 'form',
+            'nodestroy': True,
+            'target': 'new',
+            'context': self._context,
+            }
+        return action

--- a/stock_inventory_barcode/wizard/stock_inventory_barcode_view.xml
+++ b/stock_inventory_barcode/wizard/stock_inventory_barcode_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 Akretion (http://www.akretion.com/)
+    @author: Alexis de Lattre <alexis.delattre@akretion.com>
+-->
+
+<openerp>
+<data>
+
+<record id="stock_inventory_barcode_form" model="ir.ui.view">
+    <field name="name">stock.inventory.barcode.form</field>
+    <field name="model">stock.inventory.barcode</field>
+    <field name="arch"  type="xml">
+        <form string="Inventory Barcode Wizard">
+            <group name="product" string="Select Product">
+                <field name="product_code"/>
+                <field name="product_id"/>
+                <field name="theoretical_qty"/>
+                <field name="product_qty"/>
+                <field name="inventory_line_id" invisible="1"/>
+            </group>
+            <group name="qty" string="Update Quantity">
+                <field name="change_qty"/>
+                <label string="OR" colspan="2"/>
+                <field name="add_qty"/>
+            </group>
+            <footer>
+                <button name="save" type="object"
+                    class="oe_highlight" string="Update"/>
+                <button special="cancel" string="Cancel" class="oe_link"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="stock_inventory_barcode_action" model="ir.actions.act_window">
+    <field name="name">Inventory Barcode Wizard</field>
+    <field name="res_model">stock.inventory.barcode</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
See the module description for more info.

This is a REWRITE of the module proposed by initOS for v7.0 in this PR: https://github.com/OCA/stock-logistics-barcode/pull/8 (PR dated november 2014 and not merged as of today)
I rewrote this module instead of porting it to v8 for 2 reasons:
1) I think it's not a good idea to update the qty via on on_change that updates the inventory lines... as you can have several thousands inventory lines and I fear it would have bad perfs
2) You should be able to enter the new quantity with the keyboard and not just scan each item of the same product one by one (which can take a lot of time if you have a big qty of items, instead of just counting the items and entering the qty)

I kept the name of the module because it has exactly the same goal and the same use case. If you think it's a problem to keep the same name for the module, I'm OK to change the name of this module.
