### PR TITLE
[8.0][ADD][stock_disable_barcode_interface] Disable and enable the barcode interface

### DIFF
--- a/stock_disable_barcode_interface/README.rst
+++ b/stock_disable_barcode_interface/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Disable Barcode Interface
+=========================
+
+This module makes it possible to disable and enable (configurable) the barcode interface.
+
+Usage
+=====
+
+#. go to Settings -> Configuration -> Warehouse;
+#. click on 'Enable barcode interface'.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/150/8.0
+
+Known issues / Roadmap
+======================
+
+* The barcode interface continues to be accessible when directly navigated to it (/barcode/web/).
+ 
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/stock-logistics-barcode/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+stock-logistics-barcode/issues/new?body=module:%20
+stock_disable_barcode_interface%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dennis Sluijk <d.sluijk@onestein.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/stock_disable_barcode_interface/__init__.py
+++ b/stock_disable_barcode_interface/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/stock_disable_barcode_interface/__openerp__.py
+++ b/stock_disable_barcode_interface/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Disable Barcode Interface',
+    'category': 'Warehouse Management',
+    'version': '8.0.1.0.0',
+    'author': 'ONESTEiN BV, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'website': 'http://www.onestein.eu',
+    'depends': ['stock'],
+    'data': [
+        'security/stock_disable_barcode_interface_security.xml',
+        'views/stock_config_settings_view.xml',
+        'views/stock_picking_view.xml',
+        'views/stock_picking_type_view.xml',
+    ],
+    'summary': 'Disable and enable (configurable) the barcode interface'
+}

--- a/stock_disable_barcode_interface/models/__init__.py
+++ b/stock_disable_barcode_interface/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import stock_config_settings

--- a/stock_disable_barcode_interface/models/stock_config_settings.py
+++ b/stock_disable_barcode_interface/models/stock_config_settings.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2016 ONESTEiN BV (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class StockConfigSettings(models.TransientModel):
+    _inherit = 'stock.config.settings'
+
+    group_barcode_interface = fields.Boolean(
+        'Enable barcode interface',
+        implied_group='stock_disable_barcode_interface.group_enable_barcode')

--- a/stock_disable_barcode_interface/security/stock_disable_barcode_interface_security.xml
+++ b/stock_disable_barcode_interface/security/stock_disable_barcode_interface_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="group_enable_barcode" model="res.groups">
+            <field name="name">Enable Barcode Interface</field>
+        </record>
+    </data>
+</openerp>

--- a/stock_disable_barcode_interface/views/stock_config_settings_view.xml
+++ b/stock_disable_barcode_interface/views/stock_config_settings_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_stock_config_settings_enable_barcode" model="ir.ui.view">
+            <field name="name">view.stock.config.settings.enable.barcode</field>
+            <field name="model">stock.config.settings</field>
+            <field name="inherit_id" ref="stock.view_stock_config_settings"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='module_stock_picking_wave']/.." position="after">
+                    <div>
+                        <field name="group_barcode_interface" class="oe_inline"/>
+                        <label for="group_barcode_interface"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/stock_disable_barcode_interface/views/stock_picking_type_view.xml
+++ b/stock_disable_barcode_interface/views/stock_picking_type_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_stock_picking_type_kanban" model="ir.ui.view">
+            <field name="name">view.stock.picking.type.kanban</field>
+            <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
+            <field name="model">stock.picking.type</field>
+            <field name="arch" type="xml">
+                <xpath expr="//a[@name='open_barcode_interface']" position="attributes">
+                    <attribute name="groups">stock_disable_barcode_interface.group_enable_barcode</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/stock_disable_barcode_interface/views/stock_picking_view.xml
+++ b/stock_disable_barcode_interface/views/stock_picking_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_stock_picking_form" model="ir.ui.view">
+            <field name="name">view.stock.picking.form</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="model">stock.picking</field>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='do_partial_open_barcode']" position="attributes">
+                    <attribute name="groups">stock_disable_barcode_interface.group_enable_barcode</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This module makes it possible to disable and enable (configurable) the barcode interface system wide. Maybe it's a good idea to also add this configuration on operation (stock.picking.type) but I need someone to confirm this.

I'm not sure if this is the right repository.
