### PR TITLE
[FIX] Fixed scenario loading when overriding

### DIFF
--- a/stock_scanner/load_scenario.py
+++ b/stock_scanner/load_scenario.py
@@ -189,7 +189,11 @@ def import_scenario(env, module, scenario_xml, mode, directory, filename):
         transition_values = {}
         for key, item in node.items():
             if key in ['to_id', 'from_id']:
-                item = resid[get_xml_id(_('step'), module, {'id': item})]
+                step_xml_id = get_xml_id(_('step'), module, {'id': item})
+                if step_xml_id in resid:
+                    item = resid[step_xml_id]
+                else:
+                    item = env.ref(step_xml_id).id
 
             transition_values[key] = item
 


### PR DESCRIPTION
When overriding a scenario, we can add or modify transitions between steps that are not created in the current scenario. In this case, the id of the step was not in the local dictionnary.
This is fixed by calling env.ref(xml_id) to retrieve the step's id.
