### PR TITLE
[10.0][ADD] barcodes_generator_abstract: Isolate encoding types

### DIFF
--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -53,7 +53,7 @@ class BarcodeGenerateMixin(models.AbstractModel):
             if custom_code:
                 custom_code = custom_code.replace('.' * padding, str_base)
                 barcode_class = barcode.get_barcode_class(
-                    item.barcode_rule_id.encoding)
+                    item.barcode_rule_id.generate_encoding)
                 item.barcode = barcode_class(custom_code)
 
     # Custom Section

--- a/barcodes_generator_abstract/models/barcode_rule.py
+++ b/barcodes_generator_abstract/models/barcode_rule.py
@@ -45,6 +45,7 @@ class BarcodeRule(models.Model):
             ('code128', 'Code 128'),
             ('ean', 'EAN'),
             ('ean13', 'EAN-13'),
+            ('ean14', 'EAN-14'),
             ('ean8', 'EAN-8'),
             ('gs1', 'GS-1'),
             ('gtin', 'GTIN'),

--- a/barcodes_generator_abstract/views/view_barcode_rule.xml
+++ b/barcodes_generator_abstract/views/view_barcode_rule.xml
@@ -20,6 +20,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <field name="generate_type"/>
                     <field name="padding" attrs="{'invisible': [('generate_type', '=', 'no')]}"/>
                     <field name="generate_model" attrs="{'invisible': [('generate_type', '=', 'no')]}"/>
+                    <field name="generate_encoding" />
                     <vbnewline />
                     <button name="generate_sequence" type="object" string="Generate Sequence" colspan="2"
                         attrs="{'invisible': [('generate_type', '!=', 'sequence')]}"/>


### PR DESCRIPTION
I'm in a predicament right now with EAN-14, which is encoded as simply `ean` in pyBarcodes. This PR adds a new column allowing for customization of the barcode type as pyBarcodes sees it - with pass-thru for the standard encoding way that works with most everything else.

* Add generation encoding type with selection of supported types
* Add compute/inverse to allow pass-thru of normal encoding if custom not selected

cc @legalsylvain 

Tests to come, this was primarily to gather thoughts on implementation or other strategies.

Depends:
- [x] #65 