### PR TITLE
[9.0][FIX] barcodes_generator_product: Propagate barcode rule to all product variants.

### DIFF
--- a/barcodes_generator_product/demo/product.xml
+++ b/barcodes_generator_product/demo/product.xml
@@ -36,8 +36,4 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="attribute_value_ids" eval="[(6,0,[ref('product.product_attribute_value_4')])]"/>
     </record>
 
-    <record id="product_template_multi_variant" model="product.template">
-        <field name="name">Template with Generated Barcode (Multi Variant)</field>
-    </record>
-
 </odoo>

--- a/barcodes_generator_product/models/product_template.py
+++ b/barcodes_generator_product/models/product_template.py
@@ -57,3 +57,14 @@ class ProductTemplate(models.Model):
             if related_vals:
                 template.write(related_vals)
         return template
+
+    @api.multi
+    def write(self, vals):
+        """Propagate barcode rule to all variants"""
+        if 'barcode_rule_id' in vals:
+            for template in self.filtered(
+                    lambda x: x.product_variant_count > 1):
+                template.product_variant_ids.write({
+                    'barcode_rule_id': vals['barcode_rule_id'],
+                })
+        return super(ProductTemplate, self).write(vals)

--- a/barcodes_generator_product/tests/test_barcodes_generator_product.py
+++ b/barcodes_generator_product/tests/test_barcodes_generator_product.py
@@ -14,6 +14,30 @@ class Tests(TransactionCase):
         super(Tests, self).setUp()
         self.template_obj = self.env['product.template']
         self.product_obj = self.env['product.product']
+        self.barcode_rule_obj = self.env['barcode.rule']
+        
+        self.attribute = self.env['product.attribute'].create({
+            'name': 'Test Attribute',
+        })
+        self.value1 = self.env['product.attribute.value'].create({
+            'name': 'Value 1',
+            'attribute_id': self.attribute.id,
+        })
+        self.value2 = self.env['product.attribute.value'].create({
+            'name': 'Value 2',
+            'attribute_id': self.attribute.id,
+        })
+        self.barcode_product_rule = self.barcode_rule_obj.create({
+            'name': 'Test product rule',
+            'barcode_nomenclature_id': self.env.ref(
+                'barcodes.default_barcode_nomenclature').id,
+            'type': 'product',
+            'sequence': 1000,
+            'encoding': 'ean13',
+            'pattern': '20.....{NNNDD}',
+            'generate_type': 'manual',
+            'generate_model': 'product.product',
+        })
 
     # Test Section
     def test_01_manual_generation_template(self):
@@ -35,3 +59,16 @@ class Tests(TransactionCase):
             " Pattern : %s - Base : %s" % (
                 self.product_variant_1.barcode_rule_id.pattern,
                 self.product_variant_1.barcode_base))
+
+    def test_03_propagate_rule_to_variants(self):
+        template = self.template_obj.create({
+            'name': 'Product - template - Test',
+            'barcode_rule_id': self.barcode_product_rule.id,
+            'attribute_line_ids': [
+                (0, 0, {
+                    'attribute_id': self.attribute.id,
+                    'value_ids': [(6, 0, [self.value1.id, self.value2.id])]
+                })],
+        })
+        rule = template.mapped('product_variant_ids.barcode_rule_id')
+        self.assertEqual(len(rule), 1)

--- a/barcodes_generator_product/tests/test_barcodes_generator_product.py
+++ b/barcodes_generator_product/tests/test_barcodes_generator_product.py
@@ -15,7 +15,7 @@ class Tests(TransactionCase):
         self.template_obj = self.env['product.template']
         self.product_obj = self.env['product.product']
         self.barcode_rule_obj = self.env['barcode.rule']
-        
+
         self.attribute = self.env['product.attribute'].create({
             'name': 'Test Attribute',
         })


### PR DESCRIPTION
If change or when create a product with variants the rule not is propagted to all variants.
cc @Tecnativa