### PR TITLE
[10.0][IMP] barcodes_generator_abstract: Add automated generator

### DIFF
--- a/barcodes_generator_abstract/README.rst
+++ b/barcodes_generator_abstract/README.rst
@@ -9,7 +9,7 @@ Generate Barcodes for any Models (Abstract)
 This module expends Odoo functionality, allowing user to generate barcode
 depending on a given barcode rule for any Model.
 
-For exemple, a typical pattern for products is  "20.....{NNNDD}" that means
+For example, a typical pattern for products is  "20.....{NNNDD}" that means
 that:
 * the EAN13 code will begin by '20'
 * followed by 5 digits (named Barcode Base in this module)
@@ -109,7 +109,9 @@ Known issues / Roadmap
 ======================
 
 1. On barcode.rule model, constraint and domain system could be set between
-'type' and 'generate_model' fields.
+   'type' and 'generate_model' fields.
+1. Cache is being cleared in a constraint in `barcode.rule`. Mutating in a
+   constraint is bad practice & should be moved somewhere.
 
 Bug Tracker
 ===========

--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -10,8 +10,9 @@
     'version': '10.0.1.0.0',
     'category': 'Tools',
     'author':
-        'GRAP,'
-        'La Louve,'
+        'GRAP, '
+        'La Louve, '
+        'LasLabs, '
         'Odoo Community Association (OCA)',
     'website': 'https://www.odoo-community.org',
     'license': 'AGPL-3',

--- a/barcodes_generator_abstract/models/barcode_rule.py
+++ b/barcodes_generator_abstract/models/barcode_rule.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2014-Today GRAP (http://www.grap.coop)
 # Copyright (C) 2016-Today La Louve (http://www.lalouve.net)
+# Copyright 2017 LasLabs Inc.
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, exceptions, fields, models
+from odoo import _, api, exceptions, fields, models, tools
 
 _GENERATE_TYPE = [
     ('no', 'No generation'),
@@ -29,7 +30,7 @@ class BarcodeRule(models.Model):
 
     generate_model = fields.Selection(
         string='Generate Model', selection=[],
-        help="if 'Generate Type' is set, mention the model related to this"
+        help="If 'Generate Type' is set, mention the model related to this"
         " rule.")
 
     padding = fields.Integer(
@@ -38,6 +39,12 @@ class BarcodeRule(models.Model):
 
     sequence_id = fields.Many2one(
         string='Sequence', comodel_name='ir.sequence')
+
+    generate_automate = fields.Boolean(
+        string='Automatic Generation',
+        help='Check this to automatically generate a barcode upon creation of '
+             'a new record in the mixed model.',
+    )
 
     # Compute Section
     @api.depends('pattern')
@@ -53,6 +60,33 @@ class BarcodeRule(models.Model):
         for rule in self:
             if rule.generate_type == 'no':
                 rule.generate_model = False
+
+    # Constrains Section
+    @api.multi
+    @api.constrains('generate_model', 'generate_automate')
+    def _check_generate_model_automate(self):
+        """ It should not allow two automated barcode generators per model.
+
+        It also clears the cache of automated rules if necessary.
+        """
+        should_clear = False
+        for record in self:
+            if not record.generate_automate:
+                continue
+            # This query is duplicated, but necessary because the other
+            # method is cached & we need a completely current result.
+            domain = [
+                ('generate_model', '=', record.generate_model),
+                ('generate_automate', '=', True),
+            ]
+            if len(self.search(domain)) > 1:
+                raise exceptions.ValidationError(_(
+                    'Only one rule per model can be used for automatic '
+                    'barcode generation.'
+                ))
+            should_clear = True
+        if should_clear:
+            self.clear_caches()
 
     # View Section
     @api.multi
@@ -73,3 +107,21 @@ class BarcodeRule(models.Model):
             'name': _('Sequence - %s') % rule.name,
             'padding': rule.padding,
         }
+
+    @api.model
+    @tools.ormcache('model')
+    def get_automatic_rule(self, model):
+        """ It provides a cached indicator for barcode automation.
+
+        Note that this cache needs to be explicitly cleared when
+        `generate_automate` is changed on an associated `barcode.rule`.
+
+        Args:
+            model (str): Name of model to search for.
+        Returns:
+            BarcodeRule: Recordset of automated barcode rules for model.
+        """
+        return self.search([
+            ('generate_model', '=', model),
+            ('generate_automate', '=', True),
+        ])

--- a/barcodes_generator_abstract/views/view_barcode_rule.xml
+++ b/barcodes_generator_abstract/views/view_barcode_rule.xml
@@ -2,6 +2,7 @@
 <!--
 Copyright (C) 2016-Today: GRAP (http://www.grap.coop)
 Copyright (C) 2016-Today La Louve (http://www.lalouve.net)
+Copyright 2017 LasLabs Inc.
 @author Sylvain LE GAL (https://twitter.com/legalsylvain)
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
@@ -20,6 +21,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <field name="generate_type"/>
                     <field name="padding" attrs="{'invisible': [('generate_type', '=', 'no')]}"/>
                     <field name="generate_model" attrs="{'invisible': [('generate_type', '=', 'no')]}"/>
+                    <field name="generate_automate" attrs="{'invisible': [('generate_type', '=', 'no')]}"/>
                     <vbnewline />
                     <button name="generate_sequence" type="object" string="Generate Sequence" colspan="2"
                         attrs="{'invisible': [('generate_type', '!=', 'sequence')]}"/>


### PR DESCRIPTION
* Add an option to allow for automatic generation of barcode when a record of mixin model is created

This is dependent on the migration PR:
- [x] #65 

I'd like the two reviewed independently though to allow for easier back port. Relevant commit 	02d2303

Still need to test more & add actual tests, so consider this a PoC.

cc @legalsylvain 