### PR TITLE
[10.0][IMP] barcodes_generator_abstract: Add search

### DIFF
--- a/barcodes_generator_abstract/README.rst
+++ b/barcodes_generator_abstract/README.rst
@@ -76,7 +76,46 @@ model.
 Alternatively, you can develop a custom module for a custom model. See
 'Inheritance' parts.
 
-Try this module on Runbot
+Search By Barcode
+-----------------
+
+A wizard is available in the Barcode Nomenclature's action menu that allows for
+you to search for records using a barcode.
+
+For developers, there are two handy methods in `barcode.nomenclature` as well:
+
+.. code-block:: python
+
+    @api.multi
+    def find_by_barcode(self, barcode):
+        """Return the record associated with the barcode.
+
+        Args:
+            barcode (str): Barcode string to search for.
+
+        Returns:
+            BaseModel: A record matching the barcode, if existing.
+            None: No match.
+        """
+
+.. code-block:: python
+
+    @api.multi
+    def get_form_action_for_barcode(self, barcode):
+        """Return the form action for the record related to barcode.
+
+        Args:
+            barcode (str): Barcode string to search for.
+
+        Returns:
+            dict: Default form action dictionary for the barcode.
+
+        Raises:
+            UserError: If no match was found for the barcode.
+        """
+
+Try On Runbot
+-------------
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/barcodes_generator_abstract/__init__.py
+++ b/barcodes_generator_abstract/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import models
+from . import wizards

--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Generate Barcodes (Abstract)',
     'summary': 'Generate Barcodes for Any Models',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Tools',
     'author':
         'GRAP, '

--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -23,6 +23,7 @@
         'security/res_groups.xml',
         'views/view_barcode_rule.xml',
         'views/menu.xml',
+        'wizards/barcode_search_view.xml',
     ],
     'demo': [
         'demo/res_users.xml',

--- a/barcodes_generator_abstract/models/__init__.py
+++ b/barcodes_generator_abstract/models/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import barcode_generate_mixin
-
+from . import barcode_nomenclature
 from . import barcode_rule

--- a/barcodes_generator_abstract/models/barcode_nomenclature.py
+++ b/barcodes_generator_abstract/models/barcode_nomenclature.py
@@ -2,7 +2,8 @@
 # Copyright 2017 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import api, models, _
+from odoo.exceptions import UserError
 
 
 class BarcodeNomenclature(models.Model):
@@ -10,7 +11,7 @@ class BarcodeNomenclature(models.Model):
 
     @api.multi
     def find_by_barcode(self, barcode):
-        """ It returns the record associated with the barcode. """
+        """ Return the record associated with the barcode. """
         self.ensure_one()
         result = self.parse_barcode(barcode)
         if not result:
@@ -23,3 +24,16 @@ class BarcodeNomenclature(models.Model):
         return self.env[barcode_rule.generate_model].search([
             ('barcode', '=', barcode),
         ])
+
+    @api.multi
+    def get_form_action_for_barcode(self, barcode):
+        """ Return the form action for the record related to barcode. """
+        self.ensure_one()
+        barcode = self.find_by_barcode(barcode)
+        if not barcode:
+            raise UserError(
+                _('Cannot find a record matching the barcode "%s".') % (
+                    barcode,
+                ),
+            )
+        return barcode.get_formview_action()

--- a/barcodes_generator_abstract/models/barcode_nomenclature.py
+++ b/barcodes_generator_abstract/models/barcode_nomenclature.py
@@ -11,29 +11,49 @@ class BarcodeNomenclature(models.Model):
 
     @api.multi
     def find_by_barcode(self, barcode):
-        """ Return the record associated with the barcode. """
+        """Return the record associated with the barcode.
+
+        Args:
+            barcode (str): Barcode string to search for.
+
+        Returns:
+            BaseModel: A record matching the barcode, if existing.
+            None: No match.
+        """
         self.ensure_one()
         result = self.parse_barcode(barcode)
         if not result:
             return None
-        barcode_rule = self.rule_ids.filtered(
+        barcode_rules = self.rule_ids.filtered(
             lambda r: r.type == result['type'],
         )
-        if not barcode_rule.generate_model:
-            return None
-        return self.env[barcode_rule.generate_model].search([
-            ('barcode', '=', barcode),
-        ])
+        for barcode_rule in barcode_rules:
+            if not barcode_rule.generate_model:
+                continue
+            record = self.env[barcode_rule.generate_model].search([
+                ('barcode', '=', barcode),
+            ])
+            if record:
+                return record
 
     @api.multi
     def get_form_action_for_barcode(self, barcode):
-        """ Return the form action for the record related to barcode. """
-        self.ensure_one()
-        barcode = self.find_by_barcode(barcode)
-        if not barcode:
+        """Return the form action for the record related to barcode.
+
+        Args:
+            barcode (str): Barcode string to search for.
+
+        Returns:
+            dict: Default form action dictionary for the barcode.
+
+        Raises:
+            UserError: If no match was found for the barcode.
+        """
+        barcode_record = self.find_by_barcode(barcode)
+        if not barcode_record:
             raise UserError(
                 _('Cannot find a record matching the barcode "%s".') % (
                     barcode,
                 ),
             )
-        return barcode.get_formview_action()
+        return barcode_record.get_formview_action()

--- a/barcodes_generator_abstract/models/barcode_nomenclature.py
+++ b/barcodes_generator_abstract/models/barcode_nomenclature.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class BarcodeNomenclature(models.Model):
+    _inherit = 'barcode.nomenclature'
+
+    @api.multi
+    def find_by_barcode(self, barcode):
+        """ It returns the record associated with the barcode. """
+        self.ensure_one()
+        result = self.parse_barcode(barcode)
+        if not result:
+            return None
+        barcode_rule = self.rule_ids.filtered(
+            lambda r: r.type == result['type'],
+        )
+        if not barcode_rule.generate_model:
+            return None
+        return self.env[barcode_rule.generate_model].search([
+            ('barcode', '=', barcode),
+        ])

--- a/barcodes_generator_abstract/tests/__init__.py
+++ b/barcodes_generator_abstract/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_barcode_nomenclature

--- a/barcodes_generator_abstract/tests/test_barcode_nomenclature.py
+++ b/barcodes_generator_abstract/tests/test_barcode_nomenclature.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+from odoo.tests import common
+
+
+class BarcodeRule(models.Model):
+    _inherit = 'barcode.rule'
+    generate_model = fields.Selection(
+        [('product.template', 'Product Template')],
+    )
+
+
+class TestBarcodeNomenclature(common.SavepointCase):
+
+    @classmethod
+    def _init_test_model(cls, model_cls):
+        """ It builds a model from model_cls in order to test abstract models.
+        Note that this does not actually create a table in the database, so
+        there may be some unidentified edge cases.
+        Args:
+            model_cls (odoo.models.BaseModel): Class of model to initialize
+        Returns:
+            model_cls: Instance
+        """
+        registry = cls.env.registry
+        cr = cls.env.cr
+        inst = model_cls._build_model(registry, cr)
+        model = cls.env[model_cls._inherit].with_context(todo=[])
+        model._prepare_setup()
+        model._setup_base(partial=False)
+        model._setup_fields(partial=False)
+        model._setup_complete()
+        model._auto_init()
+        model.init()
+        model._auto_end()
+        cls.test_model_record = cls.env['ir.model'].search([
+            ('name', '=', model._inherit),
+        ])
+        return inst
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestBarcodeNomenclature, cls).setUpClass()
+        cls.env.registry.enter_test_mode()
+        cls._init_test_model(BarcodeRule)
+        cls.test_model = cls.env[BarcodeRule._inherit]
+
+    def setUp(self):
+        super(TestBarcodeNomenclature, self).setUp()
+        self.nomenclature = self.env.ref(
+            'barcodes.default_barcode_nomenclature',
+        )
+        self.rule = self.nomenclature.rule_ids.filtered(
+            lambda r: r.pattern == '.*'
+        )
+        self.rule.generate_model = 'product.template'
+        self.product = self.env['product.template'].search([], limit=1)
+        self.product.barcode = 'MATCH-12123234324'
+
+    def test_find_by_barcode(self):
+        """ It should find the correct record. """
+        self.assertEqual(
+            self.nomenclature.find_by_barcode(self.product.barcode),
+            self.product,
+        )
+
+    def test_find_by_barcode_no_parse_match(self):
+        """ It should return None if no matching barcode rule. """
+        self.rule.pattern = 'NOMATCH'
+        self.assertEqual(
+            self.nomenclature.find_by_barcode(self.product.barcode),
+            None,
+        )
+
+    def test_find_by_barcode_no_generate_model(self):
+        self.rule.generate_model = False
+        self.assertEqual(
+            self.nomenclature.find_by_barcode(self.product.barcode),
+            None,
+        )

--- a/barcodes_generator_abstract/tests/test_barcode_nomenclature.py
+++ b/barcodes_generator_abstract/tests/test_barcode_nomenclature.py
@@ -4,13 +4,21 @@
 
 from odoo import fields, models
 from odoo.tests import common
+from odoo.exceptions import UserError
 
 
 class BarcodeRule(models.Model):
     _inherit = 'barcode.rule'
+    _name = 'barcode.rule'
     generate_model = fields.Selection(
-        [('product.template', 'Product Template')],
+        [('ir.model', 'IrModel')],
     )
+
+
+class IrModel(models.Model):
+    _name = 'ir.model'
+    _inherit = ['ir.model', 'barcode.generate.mixin']
+    barcode = fields.Char()
 
 
 class TestBarcodeNomenclature(common.SavepointCase):
@@ -28,7 +36,7 @@ class TestBarcodeNomenclature(common.SavepointCase):
         registry = cls.env.registry
         cr = cls.env.cr
         inst = model_cls._build_model(registry, cr)
-        model = cls.env[model_cls._inherit].with_context(todo=[])
+        model = cls.env[model_cls._name].with_context(todo=[])
         model._prepare_setup()
         model._setup_base(partial=False)
         model._setup_fields(partial=False)
@@ -37,7 +45,7 @@ class TestBarcodeNomenclature(common.SavepointCase):
         model.init()
         model._auto_end()
         cls.test_model_record = cls.env['ir.model'].search([
-            ('name', '=', model._inherit),
+            ('name', '=', model._name),
         ])
         return inst
 
@@ -46,7 +54,12 @@ class TestBarcodeNomenclature(common.SavepointCase):
         super(TestBarcodeNomenclature, cls).setUpClass()
         cls.env.registry.enter_test_mode()
         cls._init_test_model(BarcodeRule)
-        cls.test_model = cls.env[BarcodeRule._inherit]
+        cls._init_test_model(IrModel)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.env.registry.leave_test_mode()
+        super(TestBarcodeNomenclature, cls).tearDownClass()
 
     def setUp(self):
         super(TestBarcodeNomenclature, self).setUp()
@@ -56,28 +69,46 @@ class TestBarcodeNomenclature(common.SavepointCase):
         self.rule = self.nomenclature.rule_ids.filtered(
             lambda r: r.pattern == '.*'
         )
-        self.rule.generate_model = 'product.template'
-        self.product = self.env['product.template'].search([], limit=1)
-        self.product.barcode = 'MATCH-12123234324'
+        self.rule.write({
+            'generate_model': 'ir.model',
+            'pattern': 'MATCH-{NNNN}',
+        })
+        self.record = self.env['ir.model'].search([], limit=1)
+        self.record.barcode = 'MATCH-1234'
 
     def test_find_by_barcode(self):
         """ It should find the correct record. """
         self.assertEqual(
-            self.nomenclature.find_by_barcode(self.product.barcode),
-            self.product,
+            self.nomenclature.find_by_barcode(self.record.barcode),
+            self.record,
         )
 
     def test_find_by_barcode_no_parse_match(self):
         """ It should return None if no matching barcode rule. """
-        self.rule.pattern = 'NOMATCH'
+        self.rule.pattern = 'NOMATCH-1234'
         self.assertEqual(
-            self.nomenclature.find_by_barcode(self.product.barcode),
+            self.nomenclature.find_by_barcode(self.record.barcode),
             None,
         )
 
     def test_find_by_barcode_no_generate_model(self):
         self.rule.generate_model = False
         self.assertEqual(
-            self.nomenclature.find_by_barcode(self.product.barcode),
+            self.nomenclature.find_by_barcode(self.record.barcode),
             None,
         )
+
+    def test_form_action_for_barcode(self):
+        """ It should return a dict. """
+        res = self.nomenclature.get_form_action_for_barcode(
+            self.record.barcode,
+        )
+        self.assertIsInstance(res, dict)
+
+    def test_form_action_for_barcode_none(self):
+        """ It should raise UserError on no match. """
+        self.rule.pattern = 'NOMATCH-1234'
+        with self.assertRaises(UserError):
+            self.nomenclature.get_form_action_for_barcode(
+                self.record.barcode,
+            )

--- a/barcodes_generator_abstract/wizards/__init__.py
+++ b/barcodes_generator_abstract/wizards/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import barcode_search

--- a/barcodes_generator_abstract/wizards/barcode_search.py
+++ b/barcodes_generator_abstract/wizards/barcode_search.py
@@ -26,7 +26,7 @@ class BarcodeSearch(models.TransientModel):
         return self.env.context.get('active_id')
 
     @api.multi
-    def search(self):
+    def action_search(self):
         self.ensure_one()
         return self.nomenclature_id.get_form_action_for_barcode(
             self.barcode,

--- a/barcodes_generator_abstract/wizards/barcode_search.py
+++ b/barcodes_generator_abstract/wizards/barcode_search.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class BarcodeSearch(models.TransientModel):
+    _name = 'barcode.search'
+
+    nomenclature_id = fields.Many2one(
+        string='Nomenclature',
+        comodel_name='barcode.nomenclature',
+        default=lambda s: s._default_nomenclature_id(),
+        required=True,
+    )
+    barcode = fields.Char(
+        required=True,
+        help='Barcode to search for.',
+    )
+
+    @api.model
+    def _default_nomenclature_id(self):
+        if self.env.context.get('active_model') != 'barcode.nomenclature':
+            return
+        return self.env.context.get('active_id')
+
+    @api.multi
+    def search(self):
+        self.ensure_one()
+        return self.nomenclature_id.get_form_action_for_barcode(
+            self.barcode,
+        )

--- a/barcodes_generator_abstract/wizards/barcode_search_view.xml
+++ b/barcodes_generator_abstract/wizards/barcode_search_view.xml
@@ -17,7 +17,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     </group>
                 </sheet>
                 <footer>
-                    <button name="search"
+                    <button name="action_search"
                             type="object"
                             string="Search" />
                 </footer>

--- a/barcodes_generator_abstract/wizards/barcode_search_view.xml
+++ b/barcodes_generator_abstract/wizards/barcode_search_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 LasLabs Inc.
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+
+    <record id="barcode_search_view_form" model="ir.ui.view">
+        <field name="model">barcode.search</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="barcode" />
+                        <field name="nomenclature_id" />
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="search"
+                            type="object"
+                            string="Search" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <act_window id="barcode_search_action"
+                name="Search Barcode"
+                res_model="barcode.search"
+                src_model="barcode.nomenclature"
+                key2="client_action_multi"
+                view_mode="form"
+                target="new"
+                view_type="form"
+                />
+
+</odoo>


### PR DESCRIPTION
This PR adds a centralized search method on `barcode.nomenclature` for barcode rules implementing the abstract generator. 

This works by first parsing the barcode against the nomenclature to determine the correct rule, then  using the `generate_model` field to identify which model to search against the `barcode` field on said model. The matched recordset is then returned.

This is very tightly coupled with the generator, so I figured it made more sense to add it as a feature vs. creating a whole new module. No harm in the extra method if someone's not using it IMO.