### PR TITLE
[10.0][FIX] travis: Switch after_success statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ script:
     - travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success


### PR DESCRIPTION
* Switch after_success from deprecated coveralls to `travis_after_tests_success`