### PR TITLE
[10.0][Fix] pip install external dependencies broken

### DIFF
--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -27,5 +27,5 @@
     'demo': [
         'demo/res_users.xml',
     ],
-    'external_dependencies': {'python': ['barcode']},
+    'external_dependencies': {'python': ['viivakoodi']},
 }


### PR DESCRIPTION
I'm not sure this will fix the (as of this posting) busted build. You can't use pip install on any of these packages right now since the Python Barcode package is busted. Now that you've switched to viivakoodi somehow the packing scripts don't know this change.