### PR TITLE
[10.0] barcodes_generator_*: add image generation wizard (+ usability improvements)

### DIFF
--- a/barcodes_generator_abstract/README.rst
+++ b/barcodes_generator_abstract/README.rst
@@ -6,34 +6,35 @@
 Generate Barcodes for any Models (Abstract)
 ===========================================
 
-This module expends Odoo functionality, allowing user to generate barcode
+This module extends Odoo functionality, allowing users to generate barcodes
 depending on a given barcode rule for any Model.
 
 For example, a typical pattern for products is  "20.....{NNNDD}" that means
 that:
-* the EAN13 code will begin by '20'
+
+* the EAN13 code will begin by *20*
 * followed by 5 digits (named Barcode Base in this module)
 * and after 5 others digits to define the variable price
-* a 13 digit control
+* a 13th control digit (checksum)
 
 With this module, it is possible to:
 
 * Affect a pattern (barcode.rule) to a model
 
-* Define a Barcode base: 
-    * manually, if the base of the barcode must be set by a user. (typically an
-      internal code defined in your company)
+* Define a Barcode base:
+    * manually, if the base of the barcode must be set by a user (typically an
+      internal code defined in your company).
     * automaticaly by a sequence, if you want to let Odoo to increment a
-      sequence. (typical case of a customer number incrementation)
+      sequence (typical case of a customer number incrementation).
 
 * Generate a barcode, based on the defined pattern and the barcode base
 
 Installation
 ============
 
-This module use an extra python library named 'viivakoodi' you should install
-to make barcode generation works properly. 'viivakoodi' is a more active for of
-'pyBarcode'.
+This module use an extra python library named *viivakoodi* you should install
+to make barcode generation works properly. *viivakoodi* is a more active fork of
+*pyBarcode*.
 
 ``sudo pip install viivakoodi``
 
@@ -69,12 +70,16 @@ Usage
 
 This module is an abstract module. You can configure Barcode Rule, but to
 enable this feature, you need to install an extra module for a given model.
-This repository provide 'barcodes_generator_product' and
-'barcodes_generator_partner' module to generate barcode for product or partner
-model.
+This repository provides several such modules:
+
+* *barcodes_generator_product* for Products,
+* *barcodes_generator_partner* for Partners,
+* *barcodes_generator_location* for Stock Locations,
+* *barcodes_generator_lot* for Production Lots/Serial Numbers,
+* *barcodes_generator_package* for Packages.
 
 Alternatively, you can develop a custom module for a custom model. See
-'Inheritance' parts.
+*Inheritance* parts.
 
 Try this module on Runbot
 
@@ -86,7 +91,7 @@ Inheritance
 ===========
 
 If you want to generate barcode for another model, you can create a custom
-module that inherits on 'barcodes_generator_abstract' and inherit your model
+module that inherits *barcodes_generator_abstract* and inherit your model
 like that:
 
 class MyModel(models.Model):
@@ -98,7 +103,7 @@ class barcode_rule(models.Model):
 
     generate_model = fields.Selection(selection_add=[('my.model', 'My Model')])
 
-Finally, you should inherit your model view adding buttons and fields.
+Finally, you should inherit your model view to add buttons and fields.
 
 Note
 ----

--- a/barcodes_generator_abstract/README.rst
+++ b/barcodes_generator_abstract/README.rst
@@ -29,6 +29,8 @@ With this module, it is possible to:
 
 * Generate a barcode, based on the defined pattern and the barcode base
 
+* Generate an image of the barcode via a wizard
+
 Installation
 ============
 

--- a/barcodes_generator_abstract/__init__.py
+++ b/barcodes_generator_abstract/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import models
+from . import wizard

--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -23,6 +23,7 @@
         'security/res_groups.xml',
         'views/view_barcode_rule.xml',
         'views/menu.xml',
+        'wizard/barcode_image_generate_view.xml',
     ],
     'demo': [
         'demo/res_users.xml',

--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -71,6 +71,12 @@ class BarcodeGenerateMixin(models.AbstractModel):
                     item.barcode_rule_id.encoding)
                 item.barcode = barcode_class(custom_code)
 
+    @api.multi
+    def clear_barcode(self):
+        for item in self:
+            if item.barcode:
+                item.barcode = False
+
     # Custom Section
     @api.model
     def _get_custom_barcode(self, item):

--- a/barcodes_generator_abstract/views/view_barcode_rule.xml
+++ b/barcodes_generator_abstract/views/view_barcode_rule.xml
@@ -24,7 +24,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <field name="generate_automate" attrs="{'invisible': [('generate_type', '=', 'no')]}"/>
                     <vbnewline />
                     <button name="generate_sequence" type="object" string="Generate Sequence" colspan="2"
-                        attrs="{'invisible': [('generate_type', '!=', 'sequence')]}"/>
+                        attrs="{'invisible': ['|', ('generate_type', '!=', 'sequence'), ('sequence_id', '!=', False)]}"/>
                     <field name="sequence_id" attrs="{'invisible': [('generate_type', '!=', 'sequence')]}"/>
                 </group>
             </field>

--- a/barcodes_generator_abstract/wizard/__init__.py
+++ b/barcodes_generator_abstract/wizard/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import barcode_image_generate

--- a/barcodes_generator_abstract/wizard/barcode_image_generate.py
+++ b/barcodes_generator_abstract/wizard/barcode_image_generate.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+from io import BytesIO
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    import barcode
+except ImportError:
+    logger.debug('Cannot import barcode')
+
+
+class BarcodeImageGenerate(models.TransientModel):
+    _name = 'barcode.image.generate'
+    _description = 'Wizard to generate a barcode image'
+
+    @api.model
+    def _supported_barcode_formats(self):
+        res = []
+        for barcode_format in barcode.PROVIDED_BARCODES:
+            res.append((barcode_format, barcode_format))
+        return res
+
+    state = fields.Selection([
+        ('config', 'config'),
+        ('download', 'download'),
+        ], default='config')
+    image_format = fields.Selection([
+        ('PNG', 'PNG'),
+        ('JPEG', 'JPEG'),
+        ], string='Image Format', default='PNG', required=True)
+    # Idea for improvement: dynamically set the list of all supported
+    # image formats from PIL ?
+    dpi = fields.Integer(string='Image Size (DPI)', default=200, required=True)
+    quiet_zone = fields.Float(
+        string='Side Space', default=1.0,
+        help="Size of the white space on the left and on the right of the "
+             "barcode")
+    write_text = fields.Boolean(
+        string='Print Barcode Text', default=True,
+        help="Print the text of the barcode under the image")
+    text_distance = fields.Float(
+        default=2.0,
+        string='Space Between Barcode and Text',
+        help="Size of the white space between the bottom of the barcode and "
+             "the text of the barcode")
+    module_height = fields.Float(
+        default=15, string='Barcode Height',
+        help="Vertical size of the barcode")
+    module_width = fields.Float(
+        default=0.2, string='Barcode Width',
+        help="It doesn't seem to have any effect in EAN13...")
+    font_size = fields.Integer(
+        default=10, string='Font Size', help="Size of the text of the barcode")
+    filename = fields.Char()
+    # the 2 fields 'image' and 'image2' have the same value
+    # 'image' is for the image widget, 'image2' is for the file widget
+    image = fields.Binary(string='Barcode Image File', readonly=True)
+    image2 = fields.Binary(string='Barcode Image File', readonly=True)
+    barcode = fields.Char(string='Barcode', readonly=True, required=True)
+    barcode_format = fields.Selection(
+        '_supported_barcode_formats', string='Barcode Format', required=True)
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super(BarcodeImageGenerate, self).default_get(fields_list)
+        if not res.get('barcode'):
+            raise UserError(_('Barcode is not set on this form!'))
+        if len(res['barcode']) == 13:
+            res['barcode_format'] = 'ean13'
+        elif len(res['barcode']) == 8:
+            res['barcode_format'] = 'ean8'
+        return res
+
+    def generate(self):
+        self.ensure_one()
+        assert self.barcode, 'Missing barcode'
+        assert self.barcode_format, 'Missing barcode format'
+        imagewriter = barcode.writer.ImageWriter()
+        imagewriter.format = self.image_format
+        imagewriter.dpi = self.dpi
+        barcode_obj = barcode.get(self.barcode_format, self.barcode)
+        fullcode = barcode_obj.get_fullcode()
+        if self.barcode != fullcode:
+            raise UserError(_(
+                "The Python Barcode library suggests that the "
+                "full barcode corresponding to the format '%s' is %s "
+                "(original barcode was %s).")
+                % (self.barcode_format, fullcode, self.barcode))
+        EAN = barcode.get_barcode_class(self.barcode_format)
+        for field in [
+                'quiet_zone', 'text_distance', 'write_text',
+                'module_height', 'module_width', 'font_size']:
+            EAN.default_writer_options[field] = self[field]
+        ean = EAN(self.barcode, writer=imagewriter)
+        fp = BytesIO()
+        ean.write(fp)
+        fp.seek(0)
+        fname = _('barcode-%s-%s.%s') % (
+            self.barcode_format, self.barcode, self.image_format.lower())
+        image_b64 = fp.read().encode('base64')
+        self.write({
+            'image': image_b64,
+            'image2': image_b64,
+            'filename': fname,
+            'state': 'download',
+        })
+        action = self.env['ir.actions.act_window'].for_xml_id(
+            'barcodes_generator_abstract', 'barcode_image_generate_action')
+        action['res_id'] = self.ids[0]
+        return action
+
+    def back2config(self):
+        self.ensure_one()
+        self.state = 'config'
+        action = self.env['ir.actions.act_window'].for_xml_id(
+            'barcodes_generator_abstract', 'barcode_image_generate_action')
+        action['res_id'] = self.ids[0]
+        return action

--- a/barcodes_generator_abstract/wizard/barcode_image_generate_view.xml
+++ b/barcodes_generator_abstract/wizard/barcode_image_generate_view.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+<record id="barcode_image_generate_form" model="ir.ui.view">
+    <field name="name">barcode.image.generate.form</field>
+    <field name="model">barcode.image.generate</field>
+    <field name="arch" type="xml">
+        <form string="Generate Barcode Image">
+            <group name="main">
+                <field name="state" invisible="1"/>
+                <field name="filename" invisible="1"/>
+                <field name="barcode"/>
+                <field name="barcode_format" attrs="{'readonly': [('state', '=', 'download')]}"/>
+            </group>
+            <group name="config" states="config" string="Image Configuration">
+                <field name="image_format"/>
+                <field name="dpi"/>
+                <field name="module_height"/>
+                <field name="module_width"/>
+                <field name="quiet_zone"/>
+                <field name="write_text"/>
+                <field name="text_distance" attrs="{'invisible': [('write_text', '=', False)]}"/>
+                <field name="font_size" attrs="{'invisible': [('write_text', '=', False)]}"/>
+            </group>
+            <group name="image" states="download" string="Image" col="1">
+                <field name="image" filename="filename" widget="image" nolabel="1"/>
+            </group>
+            <group name="download" states="download" string="Download" col="1">
+                <field name="image2" filename="filename" nolabel="1"/>
+            </group>
+            <footer>
+                <button name="generate" type="object" string="Generate Image" class="btn-primary" states="config"/>
+                <button special="cancel" string="Cancel" class="oe_link" states="config"/>
+                <button special="cancel" string="Close" class="btn-primary" states="download"/>
+                <button name="back2config" type="object" string="Back to Configuration" states="download"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="barcode_image_generate_action" model="ir.actions.act_window">
+    <field name="name">Generate Barcode Image</field>
+    <field name="res_model">barcode.image.generate</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+
+</odoo>

--- a/barcodes_generator_partner/README.rst
+++ b/barcodes_generator_partner/README.rst
@@ -27,6 +27,8 @@ With this module, it is possible to:
 
 * Generate a barcode, based on the defined pattern and the barcode base
 
+* Generate an image of the barcode via a wizard
+
 Configuration
 =============
 
@@ -51,6 +53,8 @@ To use this module, you need to:
     * click on the button 'Generate Barcode (Using Barcode Rule)'
 
 .. image:: /barcodes_generator/static/description/res_partner_sequence_generation.png
+
+If you want to generate an image of the barcode, click on *Action > Generate Barcode Image* and follow the wizard.
 
 Try this module on Runbot
 

--- a/barcodes_generator_partner/views/view_res_partner.xml
+++ b/barcodes_generator_partner/views/view_res_partner.xml
@@ -41,4 +41,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <act_window id="res_partner_barcode_image_generate"
+        key2="client_action_multi"
+        name="Generate Barcode Image"
+        res_model="barcode.image.generate"
+        src_model="res.partner"
+        view_mode="form"
+        target="new"
+        groups="barcodes_generator_abstract.generate_barcode"
+        context="{'default_barcode': barcode}"/>
+
 </odoo>

--- a/barcodes_generator_product/README.rst
+++ b/barcodes_generator_product/README.rst
@@ -28,6 +28,8 @@ With this module, it is possible to:
 
 * Generate a barcode, based on the defined pattern and the barcode base
 
+* Generate an image of the barcode via a wizard
+
 Configuration
 =============
 
@@ -53,6 +55,7 @@ To use this module, you need to:
     * click on the button 'Generate Base (Using Sequence)'
     * click on the button 'Generate Barcode (Using Barcode Rule)'
 
+If you want to generate an image of the barcode, click on *Action > Generate Barcode Image* and follow the wizard.
 
 Try this module on Runbot
 

--- a/barcodes_generator_product/models/product_template.py
+++ b/barcodes_generator_product/models/product_template.py
@@ -35,6 +35,10 @@ class ProductTemplate(models.Model):
     def generate_barcode(self):
         self.product_variant_ids.generate_barcode()
 
+    @api.multi
+    def clear_barcode(self):
+        self.product_variant_ids.clear_barcode()
+
     @api.onchange('barcode_rule_id')
     def onchange_barcode_rule_id(self):
         self.generate_type = self.barcode_rule_id.generate_type

--- a/barcodes_generator_product/views/view_product_product.xml
+++ b/barcodes_generator_product/views/view_product_product.xml
@@ -43,4 +43,15 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <act_window id="product_product_barcode_image_generate"
+        key2="client_action_multi"
+        name="Generate Barcode Image"
+        res_model="barcode.image.generate"
+        src_model="product.product"
+        view_mode="form"
+        target="new"
+        groups="barcodes_generator_abstract.generate_barcode"
+        context="{'default_barcode': barcode}"/>
+
+
 </odoo>

--- a/barcodes_generator_product/views/view_product_product.xml
+++ b/barcodes_generator_product/views/view_product_product.xml
@@ -21,21 +21,23 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     'invisible': [('barcode_rule_id', '=', False)],
                     'readonly': [('generate_type', '!=', 'manual')]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
-                <button name="generate_base" type="object" string="Generate Base (Using Sequence)" attrs="{'invisible': ['|',
-                    ('generate_type', '!=', 'sequence'),
-                    ('barcode_base', '!=', 0)]}"
+                <button name="generate_base" type="object"
+                    string="Generate Barcode Base"
+                    help="Generate Barcode Base from the sequence configured on the Barcode Rule"
+                    attrs="{'invisible': ['|',
+                        ('generate_type', '!=', 'sequence'),
+                        ('barcode_base', '!=', 0)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
 
-            <field name="barcode" position="attributes">
-                <attribute name="attrs">{'readonly': [('generate_type', '=', 'sequence')]}</attribute>
-            </field>
-
             <field name="barcode" position="after">
-                <button name="generate_barcode" type="object" string="Generate Barcode (Using Barcode Rule)"
-                    attrs="{'invisible': ['|',
+                <button name="generate_barcode" type="object"
+                    string="Generate Barcode"
+                    help="Generate a barcode using the selected Barcode Rule and the value of the Barcode Base"
+                    attrs="{'invisible': ['|', '|',
                             ('barcode_rule_id', '=', False),
-                            ('barcode_base', '=', 0)]}"
+                            ('barcode_base', '=', 0),
+                            ('barcode', '!=', False)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
         </field>

--- a/barcodes_generator_product/views/view_product_product.xml
+++ b/barcodes_generator_product/views/view_product_product.xml
@@ -29,6 +29,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                         ('barcode_base', '!=', 0)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
+            <field name="barcode" position="attributes">
+                <attribute name="attrs">{'readonly': [('barcode_rule_id', '!=', False)]}</attribute>
+            </field>
 
             <field name="barcode" position="after">
                 <button name="generate_barcode" type="object"
@@ -38,6 +41,15 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             ('barcode_rule_id', '=', False),
                             ('barcode_base', '=', 0),
                             ('barcode', '!=', False)]}"
+                    groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
+                <button name="clear_barcode" type="object"
+                    string="Clear Barcode"
+                    help="Empty the barcode field"
+                    attrs="{'invisible': ['|', '|',
+                        ('barcode_rule_id', '=', False),
+                        ('barcode_base', '=', 0),
+                        ('barcode', '=', False),
+                        ]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
         </field>

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -21,21 +21,23 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     'invisible': [('barcode_rule_id', '=', False)],
                     'readonly': [('generate_type', '!=', 'manual')]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
-                <button name="generate_base" type="object" string="Generate Base (Using Sequence)" attrs="{'invisible': ['|',
+                <button name="generate_base" type="object"
+                    string="Generate Barcode Base"
+                    help="Generate Barcode Base from the sequence configured on the Barcode Rule"
+                    attrs="{'invisible': ['|',
                     ('generate_type', '!=', 'sequence'),
                     ('barcode_base', '!=', 0)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
 
-            <field name="barcode" position="attributes">
-                <attribute name="attrs">{'readonly': [('generate_type', '=', 'sequence')]}</attribute>
-            </field>
-
             <field name="barcode" position="after">
-                <button name="generate_barcode" type="object" string="Generate Barcode (Using Barcode Rule)"
-                    attrs="{'invisible': ['|',
+                <button name="generate_barcode" type="object"
+                    string="Generate Barcode"
+                    help="Generate a barcode using the selected Barcode Rule and the value of the Barcode Base"
+                    attrs="{'invisible': ['|', '|',
                             ('barcode_rule_id', '=', False),
-                            ('barcode_base', '=', 0)]}"
+                            ('barcode_base', '=', 0),
+                            ('barcode', '!=', False)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
         </field>

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -29,7 +29,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     ('barcode_base', '!=', 0)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
-
+            <field name="barcode" position="attributes">
+                <attribute name="attrs">{'readonly': [('barcode_rule_id', '!=', False)]}</attribute>
+            </field>
             <field name="barcode" position="after">
                 <button name="generate_barcode" type="object"
                     string="Generate Barcode"
@@ -38,6 +40,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             ('barcode_rule_id', '=', False),
                             ('barcode_base', '=', 0),
                             ('barcode', '!=', False)]}"
+                    groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
+                <button name="clear_barcode" type="object"
+                    string="Clear Barcode"
+                    help="Empty the barcode field"
+                    attrs="{'invisible': ['|', '|',
+                        ('barcode_rule_id', '=', False),
+                        ('barcode_base', '=', 0),
+                        ('barcode', '=', False)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
         </field>

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -43,4 +43,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <act_window id="product_template_barcode_image_generate"
+        key2="client_action_multi"
+        name="Generate Barcode Image"
+        res_model="barcode.image.generate"
+        src_model="product.template"
+        view_mode="form"
+        target="new"
+        groups="barcodes_generator_abstract.generate_barcode"
+        context="{'default_barcode': barcode}"/>
+
 </odoo>


### PR DESCRIPTION
Don't use parenthesis in button labels, use help message to give more info.
Hide the button "Generate Barcode" when a barcode is already present.