### PR TITLE
[IMP] stock_scanner: Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,8 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  # 3 error log lines are generated during tests of the stock_scanner module, this is expected
-  - TESTS="1" SERVER_EXPECTED_ERRORS="3" ODOO_REPO="odoo/odoo"
-  - TESTS="1" SERVER_EXPECTED_ERRORS="3" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  # 3 error log lines are generated during tests of the stock_scanner module, this is expected
+  - TESTS="1" SERVER_EXPECTED_ERRORS="3" ODOO_REPO="odoo/odoo"
+  - TESTS="1" SERVER_EXPECTED_ERRORS="3" ODOO_REPO="OCA/OCB"
 
 virtualenv:
   system_site_packages: true

--- a/stock_scanner/__manifest__.py
+++ b/stock_scanner/__manifest__.py
@@ -39,9 +39,6 @@
         'demo/Tutorial/Step_types/Step_types.scenario',
         'demo/Tutorial/Sentinel/Sentinel.scenario',
         'tests/data/Test.scenario',
-        'tests/data/TestWrongModel.scenario',
-        'tests/data/TestWrongCompany.scenario',
-        'tests/data/TestWrongParent.scenario',
     ],
     'images': [
         'images/scanner_hardware.png',

--- a/stock_scanner/__manifest__.py
+++ b/stock_scanner/__manifest__.py
@@ -38,6 +38,10 @@
         'demo/Tutorial/Tutorial.scenario',
         'demo/Tutorial/Step_types/Step_types.scenario',
         'demo/Tutorial/Sentinel/Sentinel.scenario',
+        'tests/data/Test.scenario',
+        'tests/data/TestWrongModel.scenario',
+        'tests/data/TestWrongCompany.scenario',
+        'tests/data/TestWrongParent.scenario',
     ],
     'images': [
         'images/scanner_hardware.png',

--- a/stock_scanner/load_scenario.py
+++ b/stock_scanner/load_scenario.py
@@ -83,11 +83,12 @@ def import_scenario(env, module, scenario_xml, mode, directory, filename):
         elif node.tag == 'user_ids':
             if 'user_ids' not in scenario_values:
                 scenario_values['user_ids'] = []
-                user_ids = user_obj.search([
-                    ('login', '=', node.text),
-                ])
-                if user_ids:
-                    scenario_values['user_ids'].append((4, user_ids[0].id))
+
+            user_ids = user_obj.search([
+                ('login', '=', node.text),
+            ])
+            if user_ids:
+                scenario_values['user_ids'].append((4, user_ids[0].id))
         elif node.tag in ('active', 'shared_custom'):
             scenario_values[node.tag] = safe_eval(node.text) or False
         else:
@@ -118,10 +119,12 @@ def import_scenario(env, module, scenario_xml, mode, directory, filename):
                 module,
                 scenario_values['parent_id']
             )
-        scenario_values['parent_id'] = env.ref(scenario_values['parent_id']).id
-        if not scenario_values['parent_id']:
+        parent_scenario = env.ref(
+            scenario_values['parent_id'], raise_if_not_found=False)
+        if not parent_scenario:
             logger.error('Parent not found')
             return
+        scenario_values['parent_id'] = parent_scenario.id
 
     # Create or update the scenario
     ir_model_data_obj._update(

--- a/stock_scanner/load_scenario.py
+++ b/stock_scanner/load_scenario.py
@@ -102,16 +102,16 @@ def import_scenario(env, module, scenario_xml, mode, directory, filename):
             ('model', '=', scenario_values['model_id']),
         ]).id or False
         if not scenario_values['model_id']:
-            logger.error('Model not found')
-            return
+            raise ValueError(
+                'Model not found: %s' % scenario_values['model_id'])
 
     if scenario_values.get('company_id'):
         scenario_values['company_id'] = company_obj.search([
             ('name', '=', scenario_values['company_id']),
         ]).id or False
         if not scenario_values['company_id']:
-            logger.error('Company not found')
-            return
+            raise ValueError(
+                'Company not found: %s' % scenario_values['company_id'])
 
     if scenario_values.get('parent_id'):
         if '.' not in scenario_values['parent_id']:
@@ -122,8 +122,9 @@ def import_scenario(env, module, scenario_xml, mode, directory, filename):
         parent_scenario = env.ref(
             scenario_values['parent_id'], raise_if_not_found=False)
         if not parent_scenario:
-            logger.error('Parent not found')
-            return
+            raise ValueError(
+                'Parent scenario not found: %s' % scenario_values['parent_id'])
+
         scenario_values['parent_id'] = parent_scenario.id
 
     # Create or update the scenario

--- a/stock_scanner/tests/__init__.py
+++ b/stock_scanner/tests/__init__.py
@@ -3,3 +3,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_stock_scanner
+from . import test_stock_scanner_hardware
+from . import test_stock_scanner_scenario
+from . import test_stock_scanner_scenario_step
+from . import test_stock_scanner_scenario_transition
+from . import test_stock_scanner_scenario_execution
+from . import test_stock_scanner_scenario_loading

--- a/stock_scanner/tests/data/Test.scenario
+++ b/stock_scanner/tests/data/Test.scenario
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scenario>
+  <id>scanner_scenario_test</id>
+  <name>Test</name>
+  <company_id>YourCompany</company_id>
+  <model_id/>
+  <warehouse_ids>MyCompany</warehouse_ids>
+  <warehouse_ids>YourCompany</warehouse_ids>
+  <group_ids>base.group_user</group_ids>
+  <group_ids>Sentinel: technical users</group_ids>
+  <user_ids>base.user_main</user_ids>
+  <user_ids>demo</user_ids>
+  <active>False</active>
+</scenario>

--- a/stock_scanner/tests/data/TestWrongCompany.scenario
+++ b/stock_scanner/tests/data/TestWrongCompany.scenario
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scenario>
+  <id>scanner_scenario_test</id>
+  <name>Test</name>
+  <company_id>Wrong Company</company_id>
+  <model_id/>
+  <warehouse_ids>MyCompany</warehouse_ids>
+  <warehouse_ids>YourCompany</warehouse_ids>
+  <group_ids>base.group_user</group_ids>
+  <group_ids>Sentinel: technical users</group_ids>
+  <user_ids>base.user_main</user_ids>
+  <user_ids>demo</user_ids>
+  <active>False</active>
+</scenario>

--- a/stock_scanner/tests/data/TestWrongModel.scenario
+++ b/stock_scanner/tests/data/TestWrongModel.scenario
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scenario>
+  <id>scanner_scenario_test</id>
+  <name>Test</name>
+  <model_id>wrong.model</model_id>
+  <warehouse_ids>MyCompany</warehouse_ids>
+  <warehouse_ids>YourCompany</warehouse_ids>
+  <group_ids>base.group_user</group_ids>
+  <group_ids>Sentinel: technical users</group_ids>
+  <user_ids>base.user_main</user_ids>
+  <user_ids>demo</user_ids>
+  <active>False</active>
+</scenario>

--- a/stock_scanner/tests/data/TestWrongParent.scenario
+++ b/stock_scanner/tests/data/TestWrongParent.scenario
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scenario>
+  <id>scanner_scenario_test</id>
+  <name>Test</name>
+  <parent_id>Wrong Parent ID</parent_id>
+  <parent_id>Wrong.ParentID</parent_id>
+  <model_id/>
+  <warehouse_ids>MyCompany</warehouse_ids>
+  <warehouse_ids>YourCompany</warehouse_ids>
+  <group_ids>base.group_user</group_ids>
+  <group_ids>Sentinel: technical users</group_ids>
+  <user_ids>base.user_main</user_ids>
+  <user_ids>demo</user_ids>
+  <active>False</active>
+</scenario>

--- a/stock_scanner/tests/test_stock_scanner_hardware.py
+++ b/stock_scanner/tests/test_stock_scanner_hardware.py
@@ -1,0 +1,315 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+from odoo.tools.misc import mute_logger
+
+
+class TestStockScannerHardware(common.TransactionCase):
+    def setUp(self):
+        ret = super(TestStockScannerHardware, self).setUp()
+
+        self.hardware = self.env.ref('stock_scanner.scanner_hardware_1')
+
+        return ret
+
+    def test_check_scenario_without_running_scenario(self):
+        """ Should return False when no scenario is running on the hardware """
+        self.assertFalse(
+            self.env['scanner.hardware'].scanner_check(self.hardware.code))
+
+    def test_check_scenario_with_running_scenario(self):
+        """ Should return the scenario id and name from an existing hardware
+        """
+        scenario = self.env.ref('stock_scanner.scanner_scenario_tutorial')
+        self.hardware.scenario_id = scenario
+
+        values = self.env['scanner.hardware'].scanner_check(self.hardware.code)
+        scenario_id, scenario_name = values
+
+        self.assertEqual(scenario_id, scenario.id)
+        self.assertEqual(scenario_name, scenario_name)
+
+    def test_wrong_credentials(self):
+        """ Should not write the date when trying to login sith a wrong password
+        """
+        uid = self.hardware.check_credentials('wrong login', 'wrong password')
+        self.assertEqual([False], uid)
+
+    def test_wrong_login(self):
+        """ Should not write the date when trying to login sith a wrong password
+        """
+        last_date = self.hardware.last_call_dt
+        self.hardware.login('demo', 'wrong password')
+        self.assertEqual(last_date, self.hardware.last_call_dt)
+
+    def test_no_back(self):
+        """ Should not return back to the previous step if no_back """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Check linked scenario and step
+        self.assertEqual(self.hardware.scenario_id, scenario_step_types)
+        scenario_step_introduction = self.env.ref(
+            'stock_scanner.scanner_scenario_step_step_types_introduction')
+        self.assertEquals(self.hardware.step_id, scenario_step_introduction)
+
+        # Go to the next step
+        scanner_hardware.scanner_call(self.hardware.code, action='action')
+
+        # Check new linked step
+        scenario_step_message = self.env.ref(
+            'stock_scanner.scanner_scenario_step_step_types_message')
+        self.assertEquals(self.hardware.step_id, scenario_step_message)
+
+        # Define the current step as no_back
+        scenario_step_message.no_back = True
+
+        # Call the back action
+        scanner_hardware.scanner_call(self.hardware.code, action='back')
+
+        # The linked step shouldn't have been changed
+        self.assertEquals(self.hardware.step_id, scenario_step_message)
+
+    def test_step_back_on_the_first_step(self):
+        """ Should restart the first step on back action """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Check linked scenario and step
+        self.assertEqual(self.hardware.scenario_id, scenario_step_types)
+        scenario_step_introduction = self.env.ref(
+            'stock_scanner.scanner_scenario_step_step_types_introduction')
+        self.assertEquals(self.hardware.step_id, scenario_step_introduction)
+
+        # Call the back action
+        scanner_hardware.scanner_call(self.hardware.code, action='back')
+
+        # The scenario should have been restarted
+        self.assertEqual(self.hardware.scenario_id, scenario_step_types)
+
+    def test_scenario_with_no_start_step(self):
+        """ Should return an error when there is no start step """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Remove the start step of the scenario
+        scenario_step_introduction = self.env.ref(
+            'stock_scanner.scanner_scenario_step_step_types_introduction')
+        scenario_step_introduction .step_start = False
+
+        # Launch the Step types scenario
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # The scenario should have been restarted
+        self.assertEqual(ret, ('R', [
+            'Please contact', 'your', 'administrator', 'A001',
+        ], 0))
+
+    def test_no_transition(self):
+        """ Should not do anything when there is no transition """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Remove all outgoing transitions from the current step
+        self.hardware.step_id.out_transition_ids.unlink()
+
+        # Try to go to the next step
+        new_ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action')
+        self.assertEqual(new_ret, ret)
+
+    def test_no_valid_transition(self):
+        """ Should return an error when there is no valid transition """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Remove all outgoing transitions from the current step
+        self.hardware.step_id.out_transition_ids.write({
+            'condition': 'False',
+        })
+
+        # Try to go to the next step
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action')
+        self.assertEqual(ret, ('U', [
+            'Please contact', 'your', 'administrator',
+        ], 0))
+
+    def test_transition_execution_error(self):
+        """ Should return an error when a transition's condition crashes """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Remove all outgoing transitions from the current step
+        self.hardware.step_id.out_transition_ids.write({
+            'condition': 'undefined_function()',
+        })
+
+        # Try to go to the next step
+        with mute_logger('stock_scanner'):
+            ret = scanner_hardware.scanner_call(
+                self.hardware.code, action='action')
+        self.assertEqual(ret, ('R', [
+            'Please contact', 'your', 'administrator',
+        ], 0))
+
+    def test_automatic_step(self):
+        """ Should automatically go to the next step when automatic """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Remove all outgoing transitions from the current step
+        scenario_step_message = self.env.ref(
+            'stock_scanner.scanner_scenario_step_step_types_message')
+        scenario_step_message.python_code = 'act = "A"'
+
+        # Go to the next step
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action')
+        # We should be on the next next step
+        self.assertEqual(ret, ('L', [
+            ('|', 'List step'),
+            ('error', 'Go to Error step'),
+            ('continue', 'Go to next step'),
+        ], 0))
+
+    def test_log_from_scenario(self):
+        """ Should write a line in the log when calling terminal.log
+
+        This test doesn't actually really check that a line has been written,
+        but simply ensures that using the method will not crash the scenario
+        """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Activate the log for the current hardware
+        self.hardware.log_enabled = True
+        # Change the code of the next step to execute to write in the log
+        scenario_step_message = self.env.ref(
+            'stock_scanner.scanner_scenario_step_step_types_message')
+        scenario_step_message.python_code = \
+            "terminal.log('Testing the log method of scanner.hardware')\n" \
+            "act = 'M'\n" \
+            "res = []"
+
+        # Go to the next step
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action')
+        # We should be on the next next step
+        self.assertEquals(ret, ('M', [], 0))
+
+    def test_log_tracer(self):
+        """ Should write a line in the log when the transition has a tracer
+
+        This test doesn't actually really check that a line has been written,
+        but simply ensures that using a tracer will not crash the scenario
+        """
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # the result is the list of nested scenario since or scenario is a
+        # menu with the parent menu as title
+        scenario_step_types = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+
+        # Launch the Step types scenario
+        scanner_hardware.scanner_call(
+            self.hardware.code, action='action',
+            message=scenario_step_types.name)
+
+        # Activate the log for the current hardware
+        self.hardware.log_enabled = True
+        # Change the code of the next step to execute to write in the log
+        self.hardware.step_id.out_transition_ids.write({
+            'tracer': 'something',
+        })
+
+        # Go to the next step
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action')
+        # We should be on the next next step
+        self.assertEquals(ret, ('M', [
+            '|Message step',
+            '',
+            'A step designed to display some information, '
+            'without waiting for any user input.',
+        ], 0))

--- a/stock_scanner/tests/test_stock_scanner_scenario.py
+++ b/stock_scanner/tests/test_stock_scanner_scenario.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import exceptions
+from odoo.tests import common
+
+
+class TestStockScannerScenario(common.TransactionCase):
+    def test_recursive_scenarios(self):
+        """ Should raise if the scenario is recursive """
+        parent_scenario = self.env.ref(
+            'stock_scanner.scanner_scenario_tutorial')
+        child_scenario = self.env.ref(
+            'stock_scanner.scanner_scenario_sentinel')
+        with self.assertRaises(exceptions.ValidationError):
+            parent_scenario.parent_id = child_scenario

--- a/stock_scanner/tests/test_stock_scanner_scenario_execution.py
+++ b/stock_scanner/tests/test_stock_scanner_scenario_execution.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestStockScannerScenarioExecution(common.TransactionCase):
+    def setUp(self):
+        ret = super(TestStockScannerScenarioExecution, self).setUp()
+
+        self.hardware = self.env.ref('stock_scanner.scanner_hardware_1')
+        # Reset the current scenario
+        # Just in case the database has been manually used
+        self.hardware.empty_scanner_values()
+
+        return ret
+
+    def test_display_empty_submenu(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Create an empty submenu
+        menu = self.env['scanner.scenario'].create({
+            'name': 'Menu',
+            'type': 'menu',
+        })
+
+        # Call an action without any scenario running
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action', message=menu.name)
+        self.assertEqual(
+            ret, ('R', ['Scenario', 'not found'], 0))
+
+    def test_unknown_action_without_scenario(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Call an action without any scenario running
+        message = 'Some message'
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action', transition_type='scanner',
+            message=message)
+        self.assertEqual(ret, ('U', message, 0))
+
+    def test_unknown_action_with_scenario(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Enter a scenario
+        step_types_scenario = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action', message='Step types')
+        self.assertEqual(self.hardware.scenario_id, step_types_scenario)
+
+        # Call an action without any scenario running
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='unknown')
+        self.assertEqual(ret, ('R', ['Unknown', 'action'], 0))
+
+    def test_display_restart_from_main_menu(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Call an action without any scenario running
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='restart')
+        self.assertEqual(ret, ('L', ['Tutorial'], 0))
+
+    def test_display_restart_from_scenario(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Enter a scenario
+        step_types_scenario = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action', message='Step types')
+        self.assertEqual(self.hardware.scenario_id, step_types_scenario)
+
+        # Call an action without any scenario running
+        new_ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='restart')
+        self.assertEqual(new_ret, ret)
+
+    def test_display_back_from_main_menu(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Call an action without any scenario running
+        new_ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='back')
+        self.assertEqual(new_ret, ('L', ['Tutorial'], 0))
+
+    def test_display_scanner_end(self):
+        # Call to the scanner are done on the model using the scanner code
+        scanner_hardware = self.env['scanner.hardware']
+
+        # Enter a scenario
+        step_types_scenario = self.env.ref(
+            'stock_scanner.scanner_scenario_step_types')
+        ret = scanner_hardware.scanner_call(
+            self.hardware.code, action='action', message='Step types')
+        self.assertEqual(self.hardware.scenario_id, step_types_scenario)
+
+        # End the scenario
+        ret = scanner_hardware.scanner_end(self.hardware.code)
+        self.assertEqual(ret, ('F', ['This scenario', 'is finished'], ''))

--- a/stock_scanner/tests/test_stock_scanner_scenario_loading.py
+++ b/stock_scanner/tests/test_stock_scanner_scenario_loading.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import exceptions
+from odoo.tests import common
+from ..load_scenario import get_xml_id
+
+
+class TestStockScannerScenarioLoading(common.TransactionCase):
+    def test_get_xml_id_from_id(self):
+        """ Check the 'id' argument in get_xml_id """
+        xml_id = get_xml_id('element', 'stock_scanner', {
+            'id': 'the_id',
+            # Add the two values in order to check the priority
+            'reference_res_id': 'other_id',
+        })
+        self.assertEqual(xml_id, 'stock_scanner.the_id')
+
+    def test_get_xml_id_from_reference_res_id(self):
+        """ Check the 'id' argument in get_xml_id """
+        xml_id = get_xml_id('element', 'stock_scanner', {
+            'reference_res_id': 'other_id',
+        })
+        self.assertEqual(xml_id, 'stock_scanner.other_id')
+
+    def test_get_xml_id_from_full_id(self):
+        """ Check the 'id' argument in get_xml_id """
+        xml_id = get_xml_id('element', 'stock_scanner', {
+            'id': 'module_name.the_id',
+            # Add the two values in order to check the priority
+            'reference_res_id': 'other_id',
+        })
+        self.assertEqual(xml_id, 'module_name.the_id')
+
+    def test_get_xml_id_from_full_reference_res_id(self):
+        """ Check the 'id' argument in get_xml_id """
+        xml_id = get_xml_id('element', 'stock_scanner', {
+            'reference_res_id': 'module_name.other_id',
+        })
+        self.assertEqual(xml_id, 'module_name.other_id')
+
+    def test_get_xml_id_without_value(self):
+        """ Check the 'id' argument in get_xml_id """
+        with self.assertRaises(exceptions.UserError):
+            get_xml_id('element', 'stock_scanner', {})

--- a/stock_scanner/tests/test_stock_scanner_scenario_loading.py
+++ b/stock_scanner/tests/test_stock_scanner_scenario_loading.py
@@ -4,6 +4,7 @@
 
 from odoo import exceptions
 from odoo.tests import common
+from odoo.tools.convert import convert_file
 from ..load_scenario import get_xml_id
 
 
@@ -44,3 +45,27 @@ class TestStockScannerScenarioLoading(common.TransactionCase):
         """ Check the 'id' argument in get_xml_id """
         with self.assertRaises(exceptions.UserError):
             get_xml_id('element', 'stock_scanner', {})
+
+    def test_wrong_model(self):
+        """ Should raise if the model is not found """
+        with self.assertRaises(ValueError):
+            convert_file(
+                self.env.cr, 'stock_scanner',
+                'tests/data/TestWrongModel.scenario', {},
+            )
+
+    def test_wrong_company(self):
+        """ Should raise if the company is not found """
+        with self.assertRaises(ValueError):
+            convert_file(
+                self.env.cr, 'stock_scanner',
+                'tests/data/TestWrongCompany.scenario', {},
+            )
+
+    def test_wrong_parent_scenario(self):
+        """ Should raise if the parent scenario is not found """
+        with self.assertRaises(ValueError):
+            convert_file(
+                self.env.cr, 'stock_scanner',
+                'tests/data/TestWrongParent.scenario', {},
+            )

--- a/stock_scanner/tests/test_stock_scanner_scenario_step.py
+++ b/stock_scanner/tests/test_stock_scanner_scenario_step.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import exceptions
+from odoo.tests import common
+from odoo.tools.misc import mute_logger
+
+
+class TestStockScannerScenarioStep(common.TransactionCase):
+    def test_step_code_syntax(self):
+        """ Should raise if the python code contains syntax errors """
+        step = self.env.ref(
+            'stock_scanner.'
+            'scanner_scenario_step_sentinel_introduction')
+        with self.assertRaises(exceptions.ValidationError):
+            with mute_logger('stock_scanner'):
+                step.python_code = 'function('

--- a/stock_scanner/tests/test_stock_scanner_scenario_transition.py
+++ b/stock_scanner/tests/test_stock_scanner_scenario_transition.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import exceptions
+from odoo.tests import common
+from odoo.tools.misc import mute_logger
+
+
+class TestStockScannerScenarioTransition(common.TransactionCase):
+    def test_transition_scenarios(self):
+        """ Should raise if steps of a transition are on different scenarios
+        """
+        transition = self.env.ref(
+            'stock_scanner.'
+            'scanner_scenario_transition_sentinel_intro_scroll')
+        other_scenario_step = self.env.ref(
+            'stock_scanner.'
+            'scanner_scenario_step_step_types_introduction')
+        with self.assertRaises(exceptions.ValidationError):
+            transition.to_id = other_scenario_step
+
+    def test_transition_condition_syntax(self):
+        """ Should raise if the condition contains syntax errors """
+        transition = self.env.ref(
+            'stock_scanner.'
+            'scanner_scenario_transition_sentinel_intro_scroll')
+        with self.assertRaises(exceptions.ValidationError):
+            with mute_logger('stock_scanner'):
+                transition.condition = 'function('


### PR DESCRIPTION
While writing the missing unit tests before migrating the module to v11, I found some minor bugs, so I also fixed them.
I could have refactored some parts, but this was not my goal, so I didn't to keep the diff as small and readable as possible.

Notes about the modifications:
- Bad indent fix (the loading script only loaded a single user per scenario): https://github.com/OCA/stock-logistics-barcode/compare/10.0...syleam:10.0-stock_scanner-add-unit-tests?expand=1#diff-9bbbfdfa76e6771500e6a08b417ba58bL86
- Don't crash if the supplied `xml_id` for a parent scenario doesn't exist: https://github.com/OCA/stock-logistics-barcode/compare/10.0...syleam:10.0-stock_scanner-add-unit-tests?expand=1#diff-9bbbfdfa76e6771500e6a08b417ba58bL121
- Impossible value (if the `message` argument is an integer, the previous search will crash, so we can't access this line with an integer): https://github.com/OCA/stock-logistics-barcode/compare/10.0...syleam:10.0-stock_scanner-add-unit-tests?expand=1#diff-9bbbfdfa76e6771500e6a08b417ba58bL121
- Removed the `current_object` argument everywhere: Looking carefully at the code, this argument could only contain the value of the `reference_document` field, and is only used to... write its value in `reference_document`, which is totally useless. This seems to be a remaining of some old code which was refactored/deleted.
- There is always at least the first step in the history, so it's never empty: https://github.com/OCA/stock-logistics-barcode/compare/10.0...syleam:10.0-stock_scanner-add-unit-tests?expand=1#diff-653282914028649fb94eeaf68edf9f64L434