### PR TITLE
[IMP] stock_scanner: Add automatic json serialization for temporary values

### DIFF
--- a/stock_scanner/models/scanner_hardware.py
+++ b/stock_scanner/models/scanner_hardware.py
@@ -2,6 +2,7 @@
 # © 2011 Sylvain Garancher <sylvain.garancher@syleam.fr>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import json
 import logging
 import random
 import time
@@ -171,6 +172,61 @@ class ScannerHardware(models.Model):
         required=True,
         default='red',
         help='Color for the error background.')
+
+    @property
+    @api.multi
+    def json_tmp_val1(self):
+        self.ensure_one()
+        return json.loads(self.tmp_val1 or 'null')
+
+    @json_tmp_val1.setter
+    def json_tmp_val1(self, value):
+        self.ensure_one()
+        self.tmp_val1 = json.dumps(value)
+
+    @property
+    @api.multi
+    def json_tmp_val2(self):
+        self.ensure_one()
+        return json.loads(self.tmp_val2 or 'null')
+
+    @json_tmp_val2.setter
+    def json_tmp_val2(self, value):
+        self.ensure_one()
+        self.tmp_val2 = json.dumps(value)
+
+    @property
+    @api.multi
+    def json_tmp_val3(self):
+        self.ensure_one()
+        return json.loads(self.tmp_val3 or 'null')
+
+    @json_tmp_val3.setter
+    def json_tmp_val3(self, value):
+        self.ensure_one()
+        self.tmp_val3 = json.dumps(value)
+
+    @property
+    @api.multi
+    def json_tmp_val4(self):
+        self.ensure_one()
+        return json.loads(self.tmp_val4 or 'null')
+
+    @json_tmp_val4.setter
+    def json_tmp_val4(self, value):
+        self.ensure_one()
+        self.tmp_val4 = json.dumps(value)
+
+    @property
+    @api.multi
+    def json_tmp_val5(self):
+        self.ensure_one()
+        return json.loads(self.tmp_val5 or 'null')
+
+    @json_tmp_val5.setter
+    def json_tmp_val5(self, value):
+        self.ensure_one()
+        self.tmp_val5 = json.dumps(value)
 
     @api.model
     def timeout_session(self):

--- a/stock_scanner/tests/test_stock_scanner_hardware.py
+++ b/stock_scanner/tests/test_stock_scanner_hardware.py
@@ -313,3 +313,33 @@ class TestStockScannerHardware(common.TransactionCase):
             'A step designed to display some information, '
             'without waiting for any user input.',
         ], 0))
+
+    def test_data_serialization(self):
+        """ Check that json properties write the right value in tmp fields """
+        self.hardware.json_tmp_val1 = ''
+        self.assertEqual(self.hardware.tmp_val1, '""')
+        self.hardware.json_tmp_val2 = {'a': 'b', 'c': 'd'}
+        self.assertEqual(self.hardware.tmp_val2, '{"a": "b", "c": "d"}')
+        self.hardware.json_tmp_val3 = range(5)
+        self.assertEqual(self.hardware.tmp_val3, '[0, 1, 2, 3, 4]')
+        self.hardware.json_tmp_val4 = 'text value'
+        self.assertEqual(self.hardware.tmp_val4, '"text value"')
+        self.hardware.json_tmp_val5 = 13.5
+        self.assertEqual(self.hardware.tmp_val5, '13.5')
+
+    def test_data_deserialization(self):
+        """ Check that json properties write the right value in tmp fields """
+        self.hardware.tmp_val1 = '""'
+        self.assertEqual(self.hardware.json_tmp_val1, '')
+        self.hardware.tmp_val2 = '{"a": "b", "c": "d"}'
+        self.assertEqual(self.hardware.json_tmp_val2, {'a': 'b', 'c': 'd'})
+        self.hardware.tmp_val3 = '[0, 1, 2, 3, 4]'
+        self.assertEqual(self.hardware.json_tmp_val3, range(5))
+        self.hardware.tmp_val4 = '"text value"'
+        self.assertEqual(self.hardware.json_tmp_val4, 'text value')
+        self.hardware.tmp_val5 = '13.5'
+        self.assertEqual(self.hardware.json_tmp_val5, 13.5)
+
+    def test_read_unitialized_json_value(self):
+        """ Reading an uninitialized json value should return None """
+        self.assertEqual(self.hardware.json_tmp_val1, None)


### PR DESCRIPTION
Based on an idea from @gurneyalex :)

This allows to access the temporary values by using `json_tmp_valX`, which will automatically (de)serialize the data. This is useful to store complex data structures in the temporary values, without having to manually do the serialization in the scenario's code.

cc @lmignon