### PR TITLE
[FIX] barcodes_generator_abstract: Update version number to force a new upload to pypi

### DIFF
--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Generate Barcodes (Abstract)',
     'summary': 'Generate Barcodes for Any Models',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Tools',
     'author':
         'GRAP, '


### PR DESCRIPTION
Actually, ```barcode_generator_abstract``` has not the good dependencies on [pypi](https://pypi.python.org/pypi/odoo10-addon-barcodes-generator-abstract/10.0.1.0.1.99.dev1). ```barcode``` library is set as dependency but it should be ```viivakoodi``` as it was done in https://github.com/OCA/stock-logistics-barcode/pull/119.

This PR simply updates the version number to force a new upload on pypi.