### PR TITLE
[10.0][IMP] Identical name management in scenario export

### DIFF
--- a/stock_scanner/__manifest__.py
+++ b/stock_scanner/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Stock Scanner',
     'summary': 'Allows managing barcode readers with simple scenarios',
-    'version': '10.0.1.0.3',
+    'version': '10.0.1.0.4',
     'category': 'Generic Modules/Inventory Control',
     'website': 'https://odoo-community.org/',
     'author': 'SYLEAM,'

--- a/stock_scanner/scripts/export_scenario.py
+++ b/stock_scanner/scripts/export_scenario.py
@@ -2,6 +2,7 @@
 # © 2011 Christophe CHAUVET <christophe.chauvet@syleam.fr>
 # © 2011 Jean-Sébastien SUZANNE <jean-sebastien.suzanne@syleam.fr>
 # © 2015 Sylvain Garancher <sylvain.garancher@syleam.fr>
+# © 2018 Chris Tribbeck <chris.tribbeck@subteno-it.fr>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import re
@@ -34,9 +35,6 @@ group.add_option('', '--indent', dest='indent',
 group.add_option('', '--id', dest='scenario_id',
                  default=False,
                  help='id of the scenario to extract')
-group.add_option('', '--module', dest='default_module_name',
-                 default=False,
-                 help='The default name of the module (if there is no XML ID)')
 group.add_option('', '--name', dest='name',
                  default='',
                  help='Name of the scenario (default : last directory name)')
@@ -183,8 +181,9 @@ for step_id in step_ids:
         step_xmlid_counters[step_xml_id] += 1
         step_xml_id += '_%d' % (step_xmlid_counters[step_xml_id])
         step_xmlid_counters[step_xml_id] = 1
-        # This prevents problems with 2 steps named 'test' [generating 'test' and 'test_2']
-        # and a third step named 'test_2' [with this code, it will generate 'test_2_2']
+        # This prevents problems with 2 steps named 'test' [generating 'test'
+        # and 'test_2'] and a third step named 'test_2' [with this code, it
+        # will generate 'test_2_2']
     else:
         step_xmlid_counters[step_xml_id] = 1
     step['id'] = step_xml_id
@@ -231,10 +230,12 @@ for transition_id in transition_ids:
         )
     if transition_xml_id in transition_xmlid_counters:
         transition_xmlid_counters[transition_xml_id] += 1
-        transition_xml_id += '_%d' % (transition_xmlid_counters[transition_xml_id])
+        transition_xml_id += '_%d' %\
+            (transition_xmlid_counters[transition_xml_id])
         transition_xmlid_counters[transition_xml_id] = 1
-        # This prevents problems with 2 transitions named 'test' [generating 'test' and 'test_2']
-        # and a third transition named 'test_2' [with this code, it will generate 'test_2_2']
+        # This prevents problems with 2 transitions named 'test' [generating
+        # 'test' and 'test_2'] and a third transition named 'test_2' [with
+        # this code, it will generate 'test_2_2']
     else:
         transition_xmlid_counters[transition_xml_id] = 1
     transition['id'] = transition_xml_id

--- a/stock_scanner/scripts/export_scenario.py
+++ b/stock_scanner/scripts/export_scenario.py
@@ -34,6 +34,9 @@ group.add_option('', '--indent', dest='indent',
 group.add_option('', '--id', dest='scenario_id',
                  default=False,
                  help='id of the scenario to extract')
+group.add_option('', '--module', dest='default_module_name',
+                 default=False,
+                 help='The default name of the module (if there is no XML ID)')
 group.add_option('', '--name', dest='name',
                  default='',
                  help='Name of the scenario (default : last directory name)')
@@ -159,6 +162,7 @@ step_obj = Object(cnx, 'scanner.scenario.step')
 step_ids = step_obj.search([
     ('scenario_id', '=', int(opts.scenario_id)),
 ], 0, None, 'name')
+step_xmlid_counters = {}
 for step_id in step_ids:
     step = step_obj.read(step_id, [])[0]
     # delete unuse key
@@ -175,12 +179,21 @@ for step_id in step_ids:
             normalize_name(scen_read['name']),
             normalize_name(step['name']),
         )
+    if step_xml_id in step_xmlid_counters:
+        step_xmlid_counters[step_xml_id] += 1
+        step_xml_id += '_%d' % (step_xmlid_counters[step_xml_id])
+        step_xmlid_counters[step_xml_id] = 1
+        # This prevents problems with 2 steps named 'test' [generating 'test' and 'test_2']
+        # and a third step named 'test_2' [with this code, it will generate 'test_2_2']
+    else:
+        step_xmlid_counters[step_xml_id] = 1
     step['id'] = step_xml_id
 
     resid[step_id] = step_xml_id
 
     # Do not add the scenario name on the python filename
     # if this step is defined in the same module as the scenario
+    python_filename = step_xml_id
     if '.' in scenario_xml_id and '.' in step_xml_id:
         scenario_module = scenario_xml_id.split('.')[0]
         step_module = step_xml_id.split('.')[0]
@@ -188,7 +201,7 @@ for step_id in step_ids:
             python_filename = step_xml_id.split('.')[1]
 
     # save code
-    src_file = open('%s/%s.py' % (opts.directory, step_xml_id), 'w')
+    src_file = open('%s/%s.py' % (opts.directory, python_filename), 'w')
     src_file.write(step['python_code'].encode('utf-8'))
     src_file.close()
     del step['python_code']
@@ -202,6 +215,7 @@ transition_obj = Object(cnx, 'scanner.scenario.transition')
 transition_ids = transition_obj.search([
     ('from_id.scenario_id', '=', int(opts.scenario_id)),
 ], 0, None, 'name')
+transition_xmlid_counters = {}
 for transition_id in transition_ids:
     transition = transition_obj.read(transition_id, [])[0]
     del transition['scenario_id']
@@ -210,12 +224,20 @@ for transition_id in transition_ids:
 
     # get res id
     transition_xml_id = transition_obj.get_metadata(transition_id)[0]['xmlid']
-    transition['id'] = transition_xml_id
     if not transition_xml_id:
-        transition['id'] = 'scanner_scenario_%s_%s' % (
+        transition_xml_id = 'scanner_scenario_%s_%s' % (
             normalize_name(scen_read['name']),
             normalize_name(transition['name']),
         )
+    if transition_xml_id in transition_xmlid_counters:
+        transition_xmlid_counters[transition_xml_id] += 1
+        transition_xml_id += '_%d' % (transition_xmlid_counters[transition_xml_id])
+        transition_xmlid_counters[transition_xml_id] = 1
+        # This prevents problems with 2 transitions named 'test' [generating 'test' and 'test_2']
+        # and a third transition named 'test_2' [with this code, it will generate 'test_2_2']
+    else:
+        transition_xmlid_counters[transition_xml_id] = 1
+    transition['id'] = transition_xml_id
 
     # not write False in attribute tracer
     if not transition['tracer']:

--- a/stock_scanner/views/scanner_hardware.xml
+++ b/stock_scanner/views/scanner_hardware.xml
@@ -45,7 +45,7 @@
         <field name="priority" eval="8"/>
         <field name="arch" type="xml">
             <form string="Scanner Hardware">
-                <group colspan="4" col="4">
+                <group col="4">
                     <field name="code"/>
                     <field name="name"/>
                     <field name="warehouse_id"/>
@@ -54,12 +54,12 @@
                     <field name="last_call_dt"/>
                     <newline/>
                 </group>
-                <group colspan="4">
+                <group>
                     <separator string="Screen size" colspan="2"/>
                     <field name="screen_width"/>
                     <field name="screen_height"/>
                 </group>
-                <group colspan="4" col="6">
+                <group col="6">
                     <separator string="Screen colors" colspan="6"/>
                     <field name="base_fg_color"/>
                     <field name="info_fg_color"/>
@@ -68,24 +68,24 @@
                     <field name="info_bg_color"/>
                     <field name="error_bg_color"/>
                 </group>
-                <group colspan="4">
-                    <separator string="Scanner status" colspan="4"/>
+                <group>
+                    <separator string="Scanner status" colspan="2"/>
                     <field name="scenario_id"/>
                     <field name="step_id"/>
                     <field name="reference_document"/>
-                    <button string="Reset Scenario" colspan="4" type="object" icon="fa-retweet" name="empty_scanner_values"/>
+                    <button string="Reset Scenario" colspan="2" type="object" icon="fa-retweet" name="empty_scanner_values"/>
                 </group>
-                <group colspan="4">
-                    <separator string="Temporary values" colspan="4"/>
+                <group>
+                    <separator string="Temporary values" colspan="2"/>
                     <field name="tmp_val1"/>
                     <field name="tmp_val2"/>
                     <field name="tmp_val3"/>
                     <field name="tmp_val4"/>
                     <field name="tmp_val5"/>
                 </group>
-                <group colspan="4">
-                    <separator string="Current Steps History" colspan="4"/>
-                    <field name="step_history_ids" colspan="4" nolabel="1">
+                <group>
+                    <separator string="Current Steps History" colspan="2"/>
+                    <field name="step_history_ids" colspan="2" nolabel="1">
                         <tree>
                             <field name="step_id"/>
                             <field name="transition_id"/>


### PR DESCRIPTION
Added mangement for steps and transitions having identical names. Also fixed XML ID file naming.

Previously, if 2 steps or transitions had the same name, they would "share" the same XML ID so one would overwrite the other. This adds a "_2" at the end (and "_3", "_4", ...) if necessary.

Also, the filename generated contains the module name - if you generated the workflow from scratch, the first export generated `dir/step_1.py` but subsequent exports generate `dir/module.step_1.py`. Now, the module is ignored if it is the same as the scenario's module.

closes #128 