### PR TITLE
[11.0][IMP] Identical name management in scenario export

### DIFF
--- a/stock_scanner/__manifest__.py
+++ b/stock_scanner/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Stock Scanner',
     'summary': 'Allows managing barcode readers with simple scenarios',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Generic Modules/Inventory Control',
     'website': 'https://odoo-community.org/',
     'author': 'SYLEAM,'

--- a/stock_scanner/scripts/export_scenario.py
+++ b/stock_scanner/scripts/export_scenario.py
@@ -159,8 +159,9 @@ for step in sorted_steps:
         step_xmlid_counters[step_xml_id] += 1
         step_xml_id += '_%d' % (step_xmlid_counters[step_xml_id])
         step_xmlid_counters[step_xml_id] = 1
-        # This prevents problems with 2 steps named 'test' [generating 'test' and 'test_2']
-        # and a third step named 'test_2' [with this code, it will generate 'test_2_2']
+        # This prevents problems with 2 steps named 'test' [generating 'test'
+        # and 'test_2'] and a third step named 'test_2' [with this code, it
+        # will generate 'test_2_2']
     else:
         step_xmlid_counters[step_xml_id] = 1
 
@@ -176,7 +177,8 @@ for step in sorted_steps:
             python_filename = step_xml_id.split('.')[1]
 
     # Save the code of the step in a python file
-    with open('%s/%s.py' % (options.directory, python_filename), 'w') as step_file:
+    with open('%s/%s.py' % (options.directory, python_filename), 'w') as\
+            step_file:
         step_file.write(step.python_code)
 
     step_attributes = {'id': step_xml_id}
@@ -202,10 +204,12 @@ for transition in sorted_transitions:
 
     if transition_xml_id in transition_xmlid_counters:
         transition_xmlid_counters[transition_xml_id] += 1
-        transition_xml_id += '_%d' % (transition_xmlid_counters[transition_xml_id])
+        transition_xml_id += '_%d' %\
+            (transition_xmlid_counters[transition_xml_id])
         transition_xmlid_counters[transition_xml_id] = 1
-        # This prevents problems with 2 transitions named 'test' [generating 'test' and 'test_2']
-        # and a third transition named 'test_2' [with this code, it will generate 'test_2_2']
+        # This prevents problems with 2 transitions named 'test' [generating
+        # 'test' and 'test_2'] and a third transition named 'test_2' [with
+        # this code, it will generate 'test_2_2']
     else:
         transition_xmlid_counters[transition_xml_id] = 1
 


### PR DESCRIPTION
Added mangement for steps and transitions having identical names. Also fixed XML ID file naming.

Previously, if 2 steps or transitions had the same name, they would "share" the same XML ID so one would overwrite the other. This adds a "_2" at the end (and "_3", "_4", ...) if necessary.

Also, the filename generated contains the module name - if you generated the workflow from scratch, the first export generated dir/step_1.py but subsequent exports generate dir/module.step_1.py. Now, the module is ignored if it is the same as the scenario's module.

closes #128