### PR TITLE
[FIX] do not copy barcode_base during duplication

### DIFF
--- a/barcodes_generator_abstract/README.rst
+++ b/barcodes_generator_abstract/README.rst
@@ -108,10 +108,10 @@ Your model should have a field 'barcode' defined.
 Known issues / Roadmap
 ======================
 
-1. On barcode.rule model, constraint and domain system could be set between
-   'type' and 'generate_model' fields.
-1. Cache is being cleared in a constraint in `barcode.rule`. Mutating in a
-   constraint is bad practice & should be moved somewhere.
+* On barcode.rule model, constraint and domain system could be set between
+  'type' and 'generate_model' fields.
+* Cache is being cleared in a constraint in `barcode.rule`. Mutating in a
+  constraint is bad practice & should be moved somewhere.
 
 Bug Tracker
 ===========

--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Generate Barcodes (Abstract)',
     'summary': 'Generate Barcodes for Any Models',
-    'version': '10.0.1.0.2',
+    'version': '10.0.1.0.3',
     'category': 'Tools',
     'author':
         'GRAP, '

--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -27,7 +27,7 @@ class BarcodeGenerateMixin(models.AbstractModel):
     barcode_rule_id = fields.Many2one(
         string='Barcode Rule', comodel_name='barcode.rule')
 
-    barcode_base = fields.Integer(string='Barcode Base')
+    barcode_base = fields.Integer(string='Barcode Base', copy=False)
 
     generate_type = fields.Selection(
         string='Generate Type', selection=_GENERATE_TYPE, readonly=True,


### PR DESCRIPTION
Trivial PR. 
Just set copy=False on barcode_base field. This field is a kind of ID of the product to generate the barcode for product, partner, etc... 
By default it should not be copied during duplication process.

thanks for the review.