### PR TITLE
[11.0][FIX] stock_scanner: Avoid company modification

### DIFF
--- a/stock_scanner/tests/data/Test.scenario
+++ b/stock_scanner/tests/data/Test.scenario
@@ -2,7 +2,6 @@
 <scenario>
   <id>scanner_scenario_test</id>
   <name>Test</name>
-  <company_id>YourCompany</company_id>
   <model_id/>
   <warehouse_ids>MyCompany</warehouse_ids>
   <warehouse_ids>YourCompany</warehouse_ids>


### PR DESCRIPTION
This is a fix that avoid error on install when
comapny name has changed

Fix https://github.com/OCA/stock-logistics-barcode/issues/158