### PR TITLE
[FIX] stock_scanner: Pass tests with auth_crypt

### DIFF
--- a/stock_scanner/tests/test_stock_scanner.py
+++ b/stock_scanner/tests/test_stock_scanner.py
@@ -226,7 +226,7 @@ class TestStockScanner(common.TransactionCase):
             code, action='action', message=user_demo.login)
         # and the right pwd
         ret = scanner_hardware.scanner_call(
-            code, action='action', message=user_demo.password)
+            code, action='action', message="demo")
         # now we are logged in
         self.assertEqual(('F', [
             'You are now authenticated as demo !',


### PR DESCRIPTION
The value of the user's `password` field is encrypted if `auth_crypt` is installed, so that would make this test fail.

The password is always going to be "demo" anyways, so I just hardcode it here to make the test pass in integrated environments.

Notice that this is the common usage, and in fact this same file uses it in other places, both [to test it fails][1] and [to test it works][2].

[1]: https://github.com/OCA/stock-logistics-barcode/blob/d432b52538c9b9ddb35c05ade7bb9dec5ccc1c51/stock_scanner/tests/test_stock_scanner.py#L217
[2]: https://github.com/OCA/stock-logistics-barcode/blob/d432b52538c9b9ddb35c05ade7bb9dec5ccc1c51/stock_scanner/tests/test_stock_scanner.py#L272

@Tecnativa