### PR TITLE
[11.0][FIX] product_multi_aen: error on search multiple product references

### DIFF
--- a/product_multi_ean/__manifest__.py
+++ b/product_multi_ean/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Multiple EAN13 on products',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'license': 'AGPL-3',
     'author': "Camptocamp, "
               "Trey, "

--- a/product_multi_ean/tests/test_product_multi_ean.py
+++ b/product_multi_ean/tests/test_product_multi_ean.py
@@ -9,44 +9,59 @@ from ..hooks import post_init_hook
 class TestProductMultiEan(TransactionCase):
     def setUp(self):
         super(TestProductMultiEan, self).setUp()
-        self.product = self.env['product.product'].create({
-            'name': 'Test product',
+        # Product 1
+        self.product = self.env['product.product']
+        self.product_1 = self.product.create({
+            'name': 'Test product 1',
         })
-        self.valid_ean = '1234567890128'
-        self.valid_ean2 = '0123456789012'
+        self.valid_ean_1 = '1234567890128'
+        self.valid_ean2_1 = '0123456789012'
+        # Product 2
+        self.product_2 = self.product.create({
+            'name': 'Test product 2',
+        })
+        self.valid_ean_2 = '9780471117094'
+        self.valid_ean2_2 = '4006381333931'
 
     def test_set_main_ean(self):
-        self.product.barcode = self.valid_ean
-        self.assertEqual(len(self.product.ean13_ids), 1)
-        self.assertEqual(self.product.ean13_ids.name, self.product.barcode)
+        self.product_1.barcode = self.valid_ean_1
+        self.assertEqual(len(self.product_1.ean13_ids), 1)
+        self.assertEqual(self.product_1.ean13_ids.name, self.product_1.barcode)
 
     def test_set_incorrect_ean(self):
         with self.assertRaises(Exception):
-            self.product.barcode = '1234567890123'
+            self.product_1.barcode = '1234567890123'
         with self.assertRaises(Exception):
-            self.product.ean13_ids = [(0, 0, {'name': '1234567890123'})]
-        self.product.barcode = self.valid_ean
+            self.product_1.ean13_ids = [(0, 0, {'name': '1234567890123'})]
+        self.product_1.barcode = self.valid_ean_1
         # Insert duplicated EAN13
         with self.assertRaises(Exception):
-            self.product.ean13_ids = [(0, 0, {'name': self.valid_ean})]
+            self.product_1.ean13_ids = [(0, 0, {'name': self.valid_ean_1})]
 
     def test_post_init_hook(self):
         self.env.cr.execute("""
             UPDATE product_product
             SET barcode = %s
-            WHERE id = %s""", (self.valid_ean, self.product.id))
+            WHERE id = %s""", (self.valid_ean_1, self.product_1.id))
         post_init_hook(self.env.cr, self.registry)
-        self.product.refresh()
-        self.assertEqual(len(self.product.ean13_ids), 1)
-        self.assertEqual(self.product.ean13_ids.name, self.valid_ean)
+        self.product_1.refresh()
+        self.assertEqual(len(self.product_1.ean13_ids), 1)
+        self.assertEqual(self.product_1.ean13_ids.name, self.valid_ean_1)
 
     def test_search(self):
-        self.product.ean13_ids = [
-            (0, 0, {'name': self.valid_ean}),
-            (0, 0, {'name': self.valid_ean2})]
-        products = self.product.search([('barcode', '=', self.valid_ean)])
+        self.product_1.ean13_ids = [
+            (0, 0, {'name': self.valid_ean_1}),
+            (0, 0, {'name': self.valid_ean2_1})]
+        self.product_2.ean13_ids = [
+            (0, 0, {'name': self.valid_ean_2}),
+            (0, 0, {'name': self.valid_ean2_2})]
+        products = self.product.search([('barcode', '=', self.valid_ean_1)])
         self.assertEqual(len(products), 1)
-        self.assertEqual(products, self.product)
-        products = self.product.search([('barcode', '=', self.valid_ean2)])
+        self.assertEqual(products, self.product_1)
+        products = self.product.search([('barcode', '=', self.valid_ean2_1)])
         self.assertEqual(len(products), 1)
-        self.assertEqual(products, self.product)
+        self.assertEqual(products, self.product_1)
+        products = self.product.search(
+            ['|', ('barcode', '=', self.valid_ean2_1),
+             ('barcode', '=', self.valid_ean2_2)])
+        self.assertEqual(len(products), 2)


### PR DESCRIPTION
Steps to reproduce:

Go to product variants and search for 2 product references: "reference 1" + ENTER + "reference 2"
Search will crash because domain is not correctly constructed.

Current behaviour 
```AssertionError: This domain is syntactically not correct: ['|', '|', '|', ['default_code', 'ilike', 'reference 1'], ['name', 'ilike', 'reference 1'], '|', '|', ['default_code', 'ilike', 'reference 2'], ['name', 'ilike', 'reference 2'], ('ean13_ids', 'in', [])]``

Desired behaviour
<class 'list'>: ['|', '|', '|', ['default_code', 'ilike', 'reference 1'], ['name', 'ilike', 'reference 1'], ('ean13_ids', 'in', []), '|', '|', ['default_code', 'ilike', 'reference 2'], ['name', 'ilike', 'reference 2'], ('ean13_ids', 'in', [])]

CC @Eficent 

