### PR TITLE
[FIX] stock_scanner: wrong xpath in res.config.setting

### DIFF
--- a/stock_scanner/wizard/res_config_settings.xml
+++ b/stock_scanner/wizard/res_config_settings.xml
@@ -7,7 +7,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="stock.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//h2[last()]/following-sibling::div" position="after">
+            <xpath expr="//div[@data-key='stock']" position="inside">
                 <h2 id="stock_scanner_config">Configure scanner module</h2>
                 <div class="row mt16 o_settings_container">
                     <div class="col-xs-12 col-md-6 o_setting_box">


### PR DESCRIPTION
Before this commit block was appended in red area so it is not shown.
Now it in blue area for stock settings.
![изображение](https://user-images.githubusercontent.com/33932458/60677145-5d07a100-9e89-11e9-9597-3cfac094b036.png)

Closes: #183 