### PR TITLE
Update dependency in setup.py from viivakoodi to python-barcode

### DIFF
--- a/setup/barcodes_generator_abstract/setup.py
+++ b/setup/barcodes_generator_abstract/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     odoo_addon={
         'external_dependencies_override': {
             'python': {
-                'barcode': 'viivakoodi',
+                'barcode': 'python-barcode',
             },
         },
     }


### PR DESCRIPTION
The `python-barcode` project is active again and it seems to enhace
the support for python3. It also uses `Pillow` instead of `PIL`.

Ref: #193