### PR TITLE
12.0 barcodes generator product fix show fields in product template

### DIFF
--- a/barcodes_generator_product/__manifest__.py
+++ b/barcodes_generator_product/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Generate Barcodes for Products',
     'summary': 'Generate Barcodes for Products (Templates and Variants)',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Tools',
     'author':
         'GRAP,'

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -15,27 +15,36 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="barcode" position="before">
                 <field name="barcode_rule_id"
                     domain="[('generate_model', '=', 'product.product')]"
-                    groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
+                    groups="barcodes_generator_abstract.generate_barcode" colspan="2"
+                    attrs="{'invisible': [('product_variant_count', '>', 1)]}"/>
                 <field name="generate_type" invisible="1" />
                 <field name="barcode_base" attrs="{
-                    'invisible': [('barcode_rule_id', '=', False)],
+                    'invisible': ['|',
+                    ('barcode_rule_id', '=', False),
+                    ('product_variant_count', '>', 1)
+                    ],
                     'readonly': [('generate_type', '!=', 'manual')]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
-                <button name="generate_base" type="object" string="Generate Base (Using Sequence)" attrs="{'invisible': ['|',
+                <button name="generate_base" type="object" string="Generate Base (Using Sequence)" attrs="{'invisible': ['|','|',
+                    ('product_variant_count', '>', 1),
                     ('generate_type', '!=', 'sequence'),
                     ('barcode_base', '!=', 0)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
 
             <field name="barcode" position="attributes">
-                <attribute name="attrs">{'readonly': [('generate_type', '=', 'sequence')]}</attribute>
+                <attribute name="attrs">
+                        {'readonly': [('generate_type', '=', 'sequence')],
+                        'invisible': [('product_variant_count', '>', 1)]}
+                </attribute>
             </field>
 
             <field name="barcode" position="after">
                 <button name="generate_barcode" type="object" string="Generate Barcode (Using Barcode Rule)"
-                    attrs="{'invisible': ['|',
-                            ('barcode_rule_id', '=', False),
-                            ('barcode_base', '=', 0)]}"
+                    attrs="{'invisible': ['|','|',
+                    ('barcode_rule_id', '=', False),
+                    ('product_variant_count', '>', 1),
+                    ('barcode_base', '=', 0)]}"
                     groups="barcodes_generator_abstract.generate_barcode" colspan="2"/>
             </field>
         </field>


### PR DESCRIPTION
Barcode fields and buttons should be invisible if product_template has variants
Wait for https://github.com/OCA/stock-logistics-barcode/pull/201 to be merged