### PR TITLE
[11.0][FIX] stock_scanner_receipt: Take every move lines to delete

### DIFF
--- a/stock_scanner_receipt/data/Receipt/scanner_scenario_step_receipt_product_selection.py
+++ b/stock_scanner_receipt/data/Receipt/scanner_scenario_step_receipt_product_selection.py
@@ -31,7 +31,7 @@ if tracer == 'loop':
 
 elif tracer == 'picking':
     picking = env['stock.picking'].search([('name', '=', message)])
-    picking.move_lines.move_line_ids.unlink()
+    picking.move_lines.mapped('move_line_ids').unlink()
     terminal.reference_document = picking.id
 else:
     picking = env['stock.picking'].browse(terminal.reference_document)


### PR DESCRIPTION
The method returns a singleton error when the picking operation has two lines or more