### PR TITLE
[11.0][stock_barcodes] Allow to add new stock moves to a picking

### DIFF
--- a/stock_barcodes/__manifest__.py
+++ b/stock_barcodes/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": [
         'barcodes',
         'stock',
+        'stock_barcodes_automatic_entry'
     ],
     "data": [
         'security/ir.model.access.csv',

--- a/stock_barcodes/models/stock_picking.py
+++ b/stock_barcodes/models/stock_picking.py
@@ -13,7 +13,6 @@ class StockPicking(models.Model):
         manual_entry = False
         if self.state in ['draft', 'waiting', 'confirmed']:
             free_insert = True
-            manual_entry = True
         action['context'] = {
             'default_location_id': self.location_id.id,
             'default_location_dest_id': self.location_dest_id.id,

--- a/stock_barcodes/models/stock_picking.py
+++ b/stock_barcodes/models/stock_picking.py
@@ -9,14 +9,21 @@ class StockPicking(models.Model):
     def action_barcode_scan(self):
         action = self.env.ref(
             'stock_barcodes.action_stock_barcodes_read_picking').read()[0]
+        free_insert = False
+        manual_entry = False
+        if self.state in ['draft', 'waiting', 'confirmed']:
+            free_insert = True
+            manual_entry = True
         action['context'] = {
             'default_location_id': self.location_id.id,
             'default_location_dest_id': self.location_dest_id.id,
             'default_partner_id': self.partner_id.id,
             'default_picking_id': self.id,
+            'default_picking_type_id': self.picking_type_id.id,
             'default_res_model_id':
                 self.env.ref('stock.model_stock_picking').id,
             'default_res_id': self.id,
-            'default_picking_type_code': self.picking_type_code,
+            'default_free_insert': free_insert,
+            'default_manual_entry': manual_entry,
         }
         return action

--- a/stock_barcodes/models/stock_picking.py
+++ b/stock_barcodes/models/stock_picking.py
@@ -10,7 +10,8 @@ class StockPicking(models.Model):
         action = self.env.ref(
             'stock_barcodes.action_stock_barcodes_read_picking').read()[0]
         action['context'] = {
-            'default_location_id': self.location_dest_id.id,
+            'default_location_id': self.location_id.id,
+            'default_location_dest_id': self.location_dest_id.id,
             'default_partner_id': self.partner_id.id,
             'default_picking_id': self.id,
             'default_res_model_id':

--- a/stock_barcodes/models/stock_picking_type.py
+++ b/stock_barcodes/models/stock_picking_type.py
@@ -21,4 +21,7 @@ class StockPickingType(models.Model):
         elif self.code in ['outgoing', 'internal']:
             action['context'][
                 'default_location_id'] = self.default_location_src_id.id
+            if self.code == 'internal':
+                action['context']['default_location_dest_id'] = \
+                    self.default_location_dest_id.id
         return action

--- a/stock_barcodes/models/stock_picking_type.py
+++ b/stock_barcodes/models/stock_picking_type.py
@@ -13,7 +13,7 @@ class StockPickingType(models.Model):
             'default_res_model_id':
                 self.env.ref('stock.model_stock_picking_type').id,
             'default_res_id': self.id,
-            'default_picking_type_code': self.code,
+            'default_picking_type_id': self.id,
         }
         if self.code == 'incoming':
             action['context'][

--- a/stock_barcodes/static/src/js/stock_barcodes.js
+++ b/stock_barcodes/static/src/js/stock_barcodes.js
@@ -53,5 +53,11 @@ odoo.define('stock_barcodes.FormController', function(require) {
             }
             return $.when(false);
         },
+        _barcodeActiveScanned: function (method, barcode, activeBarcode) {
+            var self = this;
+            return this._super.apply(this, arguments).then(function () {
+                $(".automatic-entry").trigger('click')
+            })
+        },
     });
 });

--- a/stock_barcodes/static/src/js/stock_barcodes.js
+++ b/stock_barcodes/static/src/js/stock_barcodes.js
@@ -53,11 +53,5 @@ odoo.define('stock_barcodes.FormController', function(require) {
             }
             return $.when(false);
         },
-        _barcodeActiveScanned: function (method, barcode, activeBarcode) {
-            var self = this;
-            return this._super.apply(this, arguments).then(function () {
-                $(".automatic-entry").trigger('click')
-            })
-        },
     });
 });

--- a/stock_barcodes/static/src/js/stock_barcodes.js
+++ b/stock_barcodes/static/src/js/stock_barcodes.js
@@ -15,13 +15,19 @@ odoo.define('stock_barcodes.FormController', function(require) {
             */
             this._super(barcode, target).then(function(){
                 var manual_entry_mode = self.$("div[name='manual_entry'] input").val();
+                var free_insert = self.$("div[name='free_insert'] input").val();
                 if (manual_entry_mode){
-                    var packaging = self.$("div[name='packaging_id'] input").val();
-                    if (packaging) {
-                        self.$("input[name='packaging_qty']").focus();
+                    if (free_insert){
+                        self.$("button[name='action_manual_entry']").focus();
                     } else {
-                        self.$("input[name='product_qty']").focus();
-                    };
+                        var packaging = self.$("div[name='packaging_id'] input").val();
+                        if (packaging) {
+                            self.$("input[name='packaging_qty']").focus();
+                        } else {
+                            self.$("input[name='product_qty']").focus();
+                        };
+                    }
+
                 };
             });
         },

--- a/stock_barcodes/static/src/js/stock_barcodes.js
+++ b/stock_barcodes/static/src/js/stock_barcodes.js
@@ -38,5 +38,14 @@ odoo.define('stock_barcodes.FormController', function(require) {
                     .css({'display': 'none'});
             }
         },
+        canBeDiscarded: function(recordID) {
+            /*
+            This prevents the dialog box telling the user that changes have been made whenever we exit the form view
+            */
+            if (!this.modelName.includes("wiz.stock.barcodes.read.")) {
+                return this._super(recordID);
+            }
+            return $.when(false);
+        },
     });
 });

--- a/stock_barcodes/views/stock_picking_views.xml
+++ b/stock_barcodes/views/stock_picking_views.xml
@@ -10,8 +10,7 @@
                     class="oe_stat_button"
                     icon="fa-barcode"
                     type="object"
-                    help="Start barcode interface"
-                    states="assigned">
+                    help="Start barcode interface">
                     <div class="o_form_field o_stat_info">
                         <span class="o_stat_text">Scan barcodes</span>
                     </div>

--- a/stock_barcodes/views/stock_picking_views.xml
+++ b/stock_barcodes/views/stock_picking_views.xml
@@ -10,6 +10,7 @@
                     class="oe_stat_button"
                     icon="fa-barcode"
                     type="object"
+                    states="draft,waiting,confirmed,assigned"
                     help="Start barcode interface">
                     <div class="o_form_field o_stat_info">
                         <span class="o_stat_text">Scan barcodes</span>

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -61,6 +61,7 @@ class WizStockBarcodesRead(models.AbstractModel):
         ('success', 'Barcode read correctly'),
     ], readonly=True)
     message = fields.Char(readonly=True)
+    free_insert = fields.Boolean()
 
     @api.onchange('location_id')
     def onchange_location_id(self):

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -61,7 +61,6 @@ class WizStockBarcodesRead(models.AbstractModel):
         ('success', 'Barcode read correctly'),
     ], readonly=True)
     message = fields.Char(readonly=True)
-    free_insert = fields.Boolean()
 
     @api.onchange('location_id')
     def onchange_location_id(self):

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -48,6 +48,7 @@ class WizStockBarcodesRead(models.AbstractModel):
     manual_entry = fields.Boolean(
         string='Manual entry data',
     )
+    free_insert = fields.Boolean()
     # Computed field for display all scanning logs from res_model and res_id
     # when change product_id
     scan_log_ids = fields.Many2many(
@@ -66,6 +67,10 @@ class WizStockBarcodesRead(models.AbstractModel):
     def onchange_location_id(self):
         self.packaging_id = False
         self.product_id = False
+
+    @api.onchange('free_insert')
+    def onchange_free_insert(self):
+        self.manual_entry = self.free_insert
 
     @api.onchange('packaging_qty')
     def onchange_packaging_qty(self):
@@ -92,6 +97,10 @@ class WizStockBarcodesRead(models.AbstractModel):
                 self._set_messagge_info(
                     'more_match', _('More than one product found'))
                 return
+            if self.free_insert:
+                self.product_id = product
+                self.product_qty = 1
+                return
             self.action_product_scaned_post(product)
             self.action_done()
             return
@@ -113,6 +122,10 @@ class WizStockBarcodesRead(models.AbstractModel):
             if len(lot) == 1:
                 self.product_id = lot.product_id
             if lot:
+                if self.free_insert:
+                    self.lot_id = lot
+                    self.product_qty = 1
+                    return
                 self.action_lot_scaned_post(lot)
                 self.action_done()
                 return

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -48,7 +48,6 @@ class WizStockBarcodesRead(models.AbstractModel):
     manual_entry = fields.Boolean(
         string='Manual entry data',
     )
-    free_insert = fields.Boolean()
     # Computed field for display all scanning logs from res_model and res_id
     # when change product_id
     scan_log_ids = fields.Many2many(
@@ -68,25 +67,21 @@ class WizStockBarcodesRead(models.AbstractModel):
         self.packaging_id = False
         self.product_id = False
 
-    @api.onchange('free_insert')
-    def onchange_free_insert(self):
-        self.manual_entry = self.free_insert
-
     @api.onchange('packaging_qty')
     def onchange_packaging_qty(self):
         if self.packaging_id:
             self.product_qty = self.packaging_qty * self.packaging_id.qty
 
-    def _set_messagge_info(self, type, messagge):
+    def _set_messagge_info(self, type, message):
         """
         Set message type and message description.
         For manual entry mode barcode is not set so is not displayed
         """
         self.message_type = type
         if self.barcode:
-            self.message = _('Barcode: %s (%s)') % (self.barcode, messagge)
+            self.message = _('Barcode: %s (%s)') % (self.barcode, message)
         else:
-            self.message = '%s' % messagge
+            self.message = '%s' % message
 
     def process_barcode(self, barcode):
         self._set_messagge_info('success', _('Barcode read correctly'))
@@ -96,10 +91,6 @@ class WizStockBarcodesRead(models.AbstractModel):
             if len(product) > 1:
                 self._set_messagge_info(
                     'more_match', _('More than one product found'))
-                return
-            if self.free_insert:
-                self.product_id = product
-                self.product_qty = 1
                 return
             self.action_product_scaned_post(product)
             self.action_done()
@@ -122,10 +113,6 @@ class WizStockBarcodesRead(models.AbstractModel):
             if len(lot) == 1:
                 self.product_id = lot.product_id
             if lot:
-                if self.free_insert:
-                    self.lot_id = lot
-                    self.product_qty = 1
-                    return
                 self.action_lot_scaned_post(lot)
                 self.action_done()
                 return

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -174,11 +174,13 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                 'picking_id': self.picking_id.id,
             })
             saved_state = self.product_id, self.product_qty, self.lot_id, \
-                self.location_id, self.free_insert, self.picking_type_code
+                self.location_id, self.location_dest_id, self.free_insert, \
+                          self.picking_type_code
             moves_todo._action_confirm(merge=False)
             moves_todo._action_assign()
             self.product_id, self.product_qty, self.lot_id, self.location_id, \
-                self.free_insert, self.picking_type_code = saved_state
+                self.location_dest_id, self.free_insert, \
+                self.picking_type_code = saved_state
         if not self._search_candidate_pickings(moves_todo):
             return False
         lines = moves_todo.mapped('move_line_ids').filtered(

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -111,6 +111,9 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         self.packaging_qty = 0.0
         return result
 
+    def action_automatic_entry(self):
+        self.action_manual_entry()
+
     def _prepare_move_line_values(self, candidate_move, available_qty):
         location_id, location_dest_id = self._get_locations()
         return {

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -80,14 +80,18 @@
                     Confirmed moves allowed
                 </label>
                 <field name="confirmed_moves" widget="boolean_toggle"/>
-                <label for="free_insert" attrs="{'invisible': [('picking_id', '=', False)]}">
+                <label for="free_insert">
                     Free Insert
                 </label>
-                <field name="free_insert" widget="boolean_toggle"
-                       attrs="{'invisible': [('picking_id', '=', False)]}"/>
+                <field name="free_insert" widget="boolean_toggle"/>
+                <label for="new_picking">
+                    New Picking
+                </label>
+                <field name="new_picking" widget="boolean_toggle"/>
             </xpath>
             <field name="location_id" position="before">
-                <field name="picking_type_code" invisible="1" force_save="1"/>
+                <field name="picking_type_id" invisible="1"/>
+                <field name="picking_type_code" invisible="1"/>
                 <field name="picking_id"/>
             </field>
             <field name="location_id" position="after">

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -103,6 +103,12 @@
             <field name="product_qty" position="after">
                 <field name="picking_product_qty"/>
             </field>
+            <button name="action_manual_entry" position="after">
+                <button name="action_automatic_entry" type="object" string="Automatic entry" icon="fa-plus"
+                        attrs="{'invisible': ['|', ('manual_entry', '=', True), ('free_insert', '=', False)]}"
+                        class="btn-primary automatic-entry"
+                />
+            </button>
         </field>
     </record>
 

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -105,8 +105,7 @@
             </field>
             <button name="action_manual_entry" position="after">
                 <button name="action_automatic_entry" type="object" string="Automatic entry" icon="fa-plus"
-                        attrs="{'invisible': ['|', ('manual_entry', '=', True), ('free_insert', '=', False)]}"
-                        class="btn-primary automatic-entry"
+                        class="btn-primary barcode-automatic-entry" invisible="1"
                 />
             </button>
         </field>

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -80,10 +80,21 @@
                     Confirmed moves allowed
                 </label>
                 <field name="confirmed_moves" widget="boolean_toggle"/>
+                <label for="free_insert" attrs="{'invisible': [('picking_id', '=', False)]}">
+                    Free Insert
+                </label>
+                <field name="free_insert" widget="boolean_toggle"
+                       attrs="{'invisible': [('picking_id', '=', False)]}"/>
             </xpath>
             <field name="location_id" position="before">
                 <field name="picking_type_code" invisible="1" force_save="1"/>
                 <field name="picking_id"/>
+            </field>
+            <field name="location_id" position="after">
+                <field name="location_dest_id"
+                       attrs="{'invisible': [('picking_type_code', '!=', 'internal')],
+                               'readonly': [('manual_entry', '=', False)], 'required': [('manual_entry', '=', True)]}"
+                       force_save="1"/>
             </field>
             <field name="product_qty" position="after">
                 <field name="picking_product_qty"/>

--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -63,7 +63,7 @@
                         <field name="product_qty"  attrs="{'invisible': [('manual_entry', '=', False)], 'readonly': [('manual_entry', '=', False)]}" force_save="1" widget="FieldFloatNumericMode"/>
                     </group>
                     <group/>
-                    <group>
+                    <group col="1">
                         <button name="action_manual_entry" type="object" string="Manual entry" icon="fa-plus"
                                 attrs="{'invisible': [('manual_entry', '=', False)]}"
                                 class="btn-primary"

--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -56,7 +56,7 @@
                     </group>
                     <group>
                         <field name="product_id" options="{'no_create': True}"
-                               attrs="{'readonly': [('manual_entry', '=', False)], 'required': [('manual_entry', '=', True)]}"
+                               attrs="{'readonly': [('manual_entry', '=', False)]}"
                                force_save="1"/>
                         <field name="packaging_id" options="{'no_create': True}" domain="[('product_id', '=', product_id)]" attrs="{'readonly': [('manual_entry', '=', False)]}" force_save="1" groups="product.group_stock_packaging"/>
                         <field name="packaging_qty" attrs="{'invisible': ['|', ('packaging_id', '=', False), ('manual_entry', '=', False)], 'readonly': [('manual_entry', '=', False)]}" force_save="1" widget="FieldFloatNumericMode"/>

--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -30,12 +30,6 @@
                         </label>
                         <field name="manual_entry" widget="boolean_toggle"/>
                     </div>
-                    <div>
-                        <label for="free_insert">
-                            Free Insert
-                        </label>
-                        <field name="free_insert" widget="boolean_toggle"/>
-                    </div>
                     <field name="message_type" invisible="1" />
                     <field name="barcode" invisible="1" force_save="1"/>
                     <field name="product_tracking" invisible="1" force_save="1"/>

--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -30,6 +30,12 @@
                         </label>
                         <field name="manual_entry" widget="boolean_toggle"/>
                     </div>
+                    <div>
+                        <label for="free_insert">
+                            Free Insert
+                        </label>
+                        <field name="free_insert" widget="boolean_toggle"/>
+                    </div>
                     <field name="message_type" invisible="1" />
                     <field name="barcode" invisible="1" force_save="1"/>
                     <field name="product_tracking" invisible="1" force_save="1"/>


### PR DESCRIPTION
This PR introduces a new toggle 'Free Insert' in the barcodes wizard. When a user uses this toggle and scans a product or a lot, the system will create a new stock move and move line and add it to the picking.

This helps in processes like internal transfers, where you do not have a predefined picking like in incoming shipments or delivery orders. What the operator wants to do in this case is just do an unplanned move for a product from location A to location B. 