### PR TITLE
[FIX] stock_barcodes: out pickings default location

### DIFF
--- a/stock_barcodes/models/stock_picking.py
+++ b/stock_barcodes/models/stock_picking.py
@@ -7,10 +7,12 @@ class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     def action_barcode_scan(self):
+        out_picking = self.picking_type_code == 'outgoing'
+        location = self.location_id if out_picking else self.location_dest_id
         action = self.env.ref(
             'stock_barcodes.action_stock_barcodes_read_picking').read()[0]
         action['context'] = {
-            'default_location_id': self.location_dest_id.id,
+            'default_location_id': location.id,
             'default_partner_id': self.partner_id.id,
             'default_picking_id': self.id,
             'default_res_model_id':


### PR DESCRIPTION
In outgoing pickings setting the default location as the picking
destination one is not correct, as the resulting move line would be from
destination to destination. This patch fix it considering that when we
receive stock we want to set to wich location it will go and when send
stock we want to set from wich location we get it from.

cc @Tecnativa TT21753