### PR TITLE
[12.0] FIX barcodes_generator_abstract: when installed using pip, wrong 'barcode' library is installed

### DIFF
--- a/setup/barcodes_generator_abstract/setup.py
+++ b/setup/barcodes_generator_abstract/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'barcode': 'python-barcode',
+            },
+        },
+    },
 )


### PR DESCRIPTION
Steps:

 - Install odoo using pip
 - install `python-barcode` as required by `barcodes_generator_abstract`
 - install `odoo12-addon-barcodes-generator-abstract`

Result:
`python-barcode` and `barcode` libraries are both installed, causing `barcodes_generator_abstract` to fail with `AttributeError: module 'barcode' has no attribute 'get_barcode_class'`