### PR TITLE
[12.0][IMP][product_multi_ean] Allow install on databases with incorrect barcodes

### DIFF
--- a/product_multi_ean/models/product_product.py
+++ b/product_multi_ean/models/product_product.py
@@ -15,7 +15,6 @@ class ProductEan13(models.Model):
 
     name = fields.Char(
         string='EAN13',
-        size=13,
         required=True,
     )
     sequence = fields.Integer(


### PR DESCRIPTION
The `barcode` field in odoo doesn't have size.

In some databases, because of this, there're incorrect barcodes with digits > 13.
Without this, the module fails on install.


I got into a dilema here.
I'm not sure what's best:

- Updating the init hook like this, to ignore wrong eans:
```py
def post_init_hook(cr, registry):
    cr.execute("""
    INSERT INTO product_ean13
    (product_id, name, sequence)
    SELECT id, barcode, 0
    FROM product_product
    WHERE
        barcode IS NOT NULL
        AND LENGTH(barcode) <= 13
    """)
```

- or remove the `size=13` attribute from the ean model

Opinions?
IMO removing the varchar size makes more sense, because there's no size limit in the core module 