### PR TITLE
[12.0] ADD stock_barcodes_multi_ean

### DIFF
--- a/setup/stock_barcodes_multi_ean/odoo/addons/stock_barcodes_multi_ean
+++ b/setup/stock_barcodes_multi_ean/odoo/addons/stock_barcodes_multi_ean
@@ -1,0 +1,1 @@
+../../../../stock_barcodes_multi_ean

--- a/setup/stock_barcodes_multi_ean/setup.py
+++ b/setup/stock_barcodes_multi_ean/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_barcodes_multi_ean/__init__.py
+++ b/stock_barcodes_multi_ean/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard

--- a/stock_barcodes_multi_ean/__manifest__.py
+++ b/stock_barcodes_multi_ean/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Lorenzo Battistini @ TAKOBI
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "Stock barcodes - Multiple EAN13",
+    "summary": "Process products searching them by multiple EAN13 defined on product",
+    "version": "12.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Extra Tools",
+    "website": "https://github.com/OCA/stock-logistics-barcode",
+    "author": "TAKOBI, Odoo Community Association (OCA)",
+    "maintainers": ["eLBati"],
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "product_multi_ean",
+        "stock_barcodes",
+    ],
+    "data": [
+    ],
+}

--- a/stock_barcodes_multi_ean/readme/CONTRIBUTORS.rst
+++ b/stock_barcodes_multi_ean/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Lorenzo Battistini (https://takobi.online)

--- a/stock_barcodes_multi_ean/readme/DESCRIPTION.rst
+++ b/stock_barcodes_multi_ean/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module extends barcodes stock operations allowing to search and process products by multiple EAN13 defined in product (see `product_multi_ean` module).

--- a/stock_barcodes_multi_ean/readme/USAGE.rst
+++ b/stock_barcodes_multi_ean/readme/USAGE.rst
@@ -1,0 +1,1 @@
+In barcode interface (see stock_barcodes module) just scan a barcode configured in EAN13 list of a product.

--- a/stock_barcodes_multi_ean/tests/__init__.py
+++ b/stock_barcodes_multi_ean/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_barcodes_multi_ean

--- a/stock_barcodes_multi_ean/tests/test_stock_barcodes_multi_ean.py
+++ b/stock_barcodes_multi_ean/tests/test_stock_barcodes_multi_ean.py
@@ -1,0 +1,26 @@
+
+from odoo.addons.stock_barcodes.tests.\
+    test_stock_barcodes import TestStockBarcodes
+
+
+class TestStockBarcodesMultiEan(TestStockBarcodes):
+
+    def setUp(self):
+        super().setUp()
+        self.extra_ean = '8411822222570'
+
+    def test_stock_barcodes_supplierinfo(self):
+        self.action_barcode_scanned(self.wiz_scan, self.lot_1.name)
+        # check scanning lot is still working
+        self.assertEqual(self.wiz_scan.lot_id.name, self.lot_1.name)
+        self.assertEqual(
+            self.wiz_scan.message, 'Barcode: 8411822222568 (Barcode read correctly)')
+        self.action_barcode_scanned(self.wiz_scan, self.extra_ean)
+        self.assertEqual(
+            self.wiz_scan.message, 'Barcode: 8411822222570 (Barcode not found)')
+        self.product_tracking.ean13_ids = [(0, 0, {
+            'name': self.extra_ean,
+        })]
+        self.action_barcode_scanned(self.wiz_scan, self.extra_ean)
+        self.assertEqual(
+            self.wiz_scan.message, 'Barcode: 8411822222570 (Barcode read correctly)')

--- a/stock_barcodes_multi_ean/wizard/__init__.py
+++ b/stock_barcodes_multi_ean/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_barcodes_read

--- a/stock_barcodes_multi_ean/wizard/stock_barcodes_read.py
+++ b/stock_barcodes_multi_ean/wizard/stock_barcodes_read.py
@@ -1,0 +1,23 @@
+from odoo import models, _
+
+
+class WizStockBarcodesRead(models.AbstractModel):
+    _inherit = 'wiz.stock.barcodes.read'
+
+    def process_barcode(self, barcode):
+        domain = self._barcode_domain(barcode)
+        product = self.env['product.product'].search(domain)
+        if not product:
+            # also search by multiple EAN
+            product = self.env['product.product'].search([
+                ('ean13_ids.name', '=', barcode)])
+            if len(product) > 1:
+                self._set_messagge_info(
+                    'more_match', _('More than one product found'))
+                return
+            if product:
+                self.action_product_scaned_post(product)
+                self.action_done()
+                self._set_messagge_info('success', _('Barcode read correctly'))
+                return
+        return super(WizStockBarcodesRead, self).process_barcode(barcode)


### PR DESCRIPTION
This module extends barcodes stock operations allowing to search and process products by multiple EAN13 defined in product (see `product_multi_ean` module).