### PR TITLE
[FIX] stock_barcodes: tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-barcode
+python-barcode == 0.12.0

--- a/stock_barcodes/tests/test_stock_barcodes_inventory.py
+++ b/stock_barcodes/tests/test_stock_barcodes_inventory.py
@@ -27,8 +27,10 @@ class TestStockBarcodesInventory(TestStockBarcodes):
                          self.stock_inventory_model)
         self.assertEqual(self.wiz_scan_inventory.res_id,
                          self.inventory.id)
-        self.assertEqual(self.wiz_scan_inventory.display_name,
-                         'Barcode reader - Test Inventory - OdooBot')
+        self.assertIn(
+            "Barcode reader - Test Inventory - ",
+            self.wiz_scan_inventory.display_name,
+        )
 
     def test_inventory_wizard_scan_product(self):
         self.action_barcode_scanned(self.wiz_scan_inventory, '8480000723208')

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -93,9 +93,10 @@ class TestStockBarcodesPicking(TestStockBarcodes):
                          self.stock_picking_model)
         self.assertEqual(self.wiz_scan_picking.res_id,
                          self.picking_in_01.id)
-        self.assertEqual(self.wiz_scan_picking.display_name,
-                         'Barcode reader - %s - OdooBot' % (
-                             self.picking_in_01.name))
+        self.assertIn(
+            "Barcode reader - %s - " % (self.picking_in_01.name),
+            self.wiz_scan_picking.display_name,
+        )
 
     def test_picking_wizard_scan_product(self):
         self.action_barcode_scanned(self.wiz_scan_picking, '8480000723208')


### PR DESCRIPTION
- The system user name is `System` by default and `OdooBot` when
`mail_bot` is installed so the resulting string could change
- `python-barcode` requires python 3.6 from version 0.13.0 so until Odoo
oficially supports it we'll have to stick to this version.

cc @Tecnativa TT25264