### PR TITLE
[12.0][IMP] stock_barcodes_gs1: Allow the use of double GS1-128 barcodes

### DIFF
--- a/stock_barcodes_gs1/tests/test_stock_barcodes_gs1.py
+++ b/stock_barcodes_gs1/tests/test_stock_barcodes_gs1.py
@@ -10,7 +10,10 @@ class TestStockBarcodesGS1(TestStockBarcodes):
     def setUp(self):
         super().setUp()
         # Barcode for packaging and lot
-        self.gs1_barcode_01 = '01195011015300001714070410AB-123'
+        self.gs1_barcode_01_product = '0119501101530000'
+        self.gs1_barcode_01_lot = '1714070410AB-123'
+        self.gs1_barcode_01 = (
+            self.gs1_barcode_01_product + self.gs1_barcode_01_lot)
         self.gs1_barcode_01_not_found = '011xxx11015300001714070410AB-123'
         self.gs1_barcode_01_not_lot = '01195011015300001714070410AB-124'
         # Barcode for product and quantities
@@ -30,6 +33,25 @@ class TestStockBarcodesGS1(TestStockBarcodes):
             'qty': 10.0,
             'barcode': '19501101530000',
         })
+
+    def test_wizard_scan_gs1_package_multi(self):
+        self.packaging_gs1.product_id = self.product_tracking_gs1
+        lot = self.StockProductionLot.create({
+            'name': 'AB-123',
+            'product_id': self.product_tracking_gs1.id,
+        })
+        self.action_barcode_scanned(self.wiz_scan, self.gs1_barcode_01_product)
+        self.assertEqual(self.wiz_scan.product_id, self.product_tracking_gs1)
+        self.assertEqual(self.wiz_scan.packaging_id, self.packaging_gs1)
+        self.assertFalse(self.wiz_scan.lot_id)
+        self.assertEqual(self.wiz_scan.packaging_qty, 1)
+        self.assertEqual(self.wiz_scan.product_qty, 10)
+        self.action_barcode_scanned(self.wiz_scan, self.gs1_barcode_01_lot)
+        self.assertEqual(self.wiz_scan.product_id, self.product_tracking_gs1)
+        self.assertEqual(self.wiz_scan.packaging_id, self.packaging_gs1)
+        self.assertEqual(self.wiz_scan.lot_id, lot)
+        self.assertEqual(self.wiz_scan.packaging_qty, 1)
+        self.assertEqual(self.wiz_scan.product_qty, 10)
 
     def test_wizard_scan_gs1_package(self):
         self.action_barcode_scanned(self.wiz_scan, self.gs1_barcode_01)

--- a/stock_barcodes_gs1/wizard/stock_barcodes_read.py
+++ b/stock_barcodes_gs1/wizard/stock_barcodes_read.py
@@ -74,6 +74,13 @@ class WizStockBarcodesRead(models.AbstractModel):
             processed = True
         if product_qty:
             self.product_qty = product_qty
+        if not self.product_qty:
+            # This could happen with double GS1-128 barcodes
+            if self.packaging_id:
+                self.packaging_qty = 0.0 if self.manual_entry else 1.0
+                self.product_qty = self.packaging_id.qty * self.packaging_qty
+            else:
+                self.product_qty = 0.0 if self.manual_entry else 1.0
         if processed:
             self.action_done()
             self._set_messagge_info('success', _('Barcode read correctly'))


### PR DESCRIPTION
This way we can use barcodes like the following:

![imagen](https://user-images.githubusercontent.com/28590170/93789224-e0014c80-fc31-11ea-875c-f7a0dff3f6e5.png)


@LoisRForgeFlow