### PR TITLE
[IMP] stock_barcodes: allow to add lines even if not qtys reserved

### DIFF
--- a/stock_barcodes/views/stock_picking_views.xml
+++ b/stock_barcodes/views/stock_picking_views.xml
@@ -11,7 +11,7 @@
                     icon="fa-barcode"
                     type="object"
                     help="Start barcode interface"
-                    states="assigned">
+                    states="confirmed,assigned">
                     <div class="o_form_field o_stat_info">
                         <span class="o_stat_text">Scan barcodes</span>
                     </div>


### PR DESCRIPTION
If we had no reservation (i.e unreserve), the barcodes button was hidden.

cc @Tecnativa TT27070