### PR TITLE
[12.0][IMP] stock_barcodes: add html field to track pending products

### DIFF
--- a/stock_barcodes/__manifest__.py
+++ b/stock_barcodes/__manifest__.py
@@ -23,6 +23,7 @@
         'wizard/stock_barcodes_read_views.xml',
         'wizard/stock_barcodes_read_inventory_views.xml',
         'wizard/stock_barcodes_read_picking_views.xml',
+        'templates/missing_moves_template.xml',
     ],
     "installable": True,
 }

--- a/stock_barcodes/__manifest__.py
+++ b/stock_barcodes/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     "data": [
         'security/ir.model.access.csv',
+        'security/security.xml',
         'views/assets.xml',
         'views/res_config_settings_views.xml',
         'views/stock_inventory_views.xml',

--- a/stock_barcodes/models/res_config_settings.py
+++ b/stock_barcodes/models/res_config_settings.py
@@ -12,6 +12,11 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.stock_barcodes_inventory_auto_lot",
         readonly=False,
     )
+    group_track_pending_products_picking_barcode_wizard = fields.Boolean(
+        string="Track pending products at the picking barcode wizard",
+        implied_group="stock_barcodes."
+                      "group_track_pending_products_picking_barcode",
+    )
 
 
 class ResCompany(models.Model):

--- a/stock_barcodes/security/security.xml
+++ b/stock_barcodes/security/security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Creu Blanca
+    License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+-->
+<odoo>
+    <record id="group_track_pending_products_picking_barcode" model="res.groups">
+        <field name="name">Add table to track pending products at picking stock wizard</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+</odoo>

--- a/stock_barcodes/templates/missing_moves_template.xml
+++ b/stock_barcodes/templates/missing_moves_template.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="missing_moves">
+        <div class="table-responsive" t-if="moves">
+        <table class='o_list_view table table-sm table-hover table-striped o_list_view_ungrouped'>
+            <thead>
+            <tr>
+                <th class="o_column_sortable">Product</th>
+                <th class="o_column_sortable">Initial Demand</th>
+                <th class="o_column_sortable">Done</th>
+            </tr>
+            </thead>
+            <tr t-foreach="moves" t-as="move">
+                <td>
+                    <span t-field="move.product_id"/>
+                </td>
+                <td>
+                    <span t-field="move.product_uom_qty"/>
+                </td>
+                <td>
+                    <span t-field="move.quantity_done"/>
+                </td>
+            </tr>
+            <tfoot class="oe_foot">
+                <tr>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </tfoot>
+        </table>
+        </div>
+        <div t-else="">
+            <h3>No pending operations</h3>
+        </div>
+    </template>
+</odoo>

--- a/stock_barcodes/templates/missing_moves_template.xml
+++ b/stock_barcodes/templates/missing_moves_template.xml
@@ -23,9 +23,7 @@
             </tr>
             <tfoot class="oe_foot">
                 <tr>
-                    <td></td>
-                    <td></td>
-                    <td></td>
+                    <td colspan="3"/>
                 </tr>
             </tfoot>
         </table>

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo.addons.stock_barcodes.tests.test_stock_barcodes import\
     TestStockBarcodes
+from lxml import etree
 
 
 class TestStockBarcodesPicking(TestStockBarcodes):
@@ -129,6 +130,37 @@ class TestStockBarcodesPicking(TestStockBarcodes):
         self.action_barcode_scanned(self.wiz_scan_picking, '5420008510489')
         # Package of 5 product units. Already three unit exists
         self.assertEqual(sml.qty_done, 8.0)
+
+    def test_compute_pending_products(self):
+        self.assertTrue(self.wiz_scan_picking.pending_moves)
+        for i in range(0, 8):
+            view = etree.fromstring(self.wiz_scan_picking.pending_moves)
+            node = view.xpath("//table/tr/td/span[text() = '%s']/../.."
+                              % self.product_tracking.name)
+            self.assertTrue(node)
+            quantity_done = node[0].xpath('td[last()]/span')
+            self.assertEqual(i, float(quantity_done[0].text))
+            node = view.xpath("//table/tr/td/span[text() = '%s']/../.."
+                              % self.product_wo_tracking.name)
+            self.assertTrue(node)
+            quantity_done = node[0].xpath('td[last()]/span')
+            self.assertEqual(0, float(quantity_done[0].text))
+            self.action_barcode_scanned(self.wiz_scan_picking, '8411822222568')
+        view = etree.fromstring(self.wiz_scan_picking.pending_moves)
+        node = view.xpath("//table/tr/td/span[text() = '%s']/../.."
+                          % self.product_tracking.name)
+        self.assertFalse(node)
+        node = view.xpath("//table/tr/td/span[text() = '%s']/../.."
+                          % self.product_wo_tracking.name)
+        self.assertTrue(node)
+        quantity_done = node[0].xpath('td[last()]/span')
+        self.assertEqual(0, float(quantity_done[0].text))
+        move = self.wiz_scan_picking.picking_id.move_ids_without_package.\
+            filtered(
+                lambda r: r.product_id == self.product_wo_tracking)
+        move.quantity_done = move.product_uom_qty
+        self.assertRegex(self.wiz_scan_picking.pending_moves,
+                         ".*No pending operations.*")
 
     def test_picking_wizard_scan_product_manual_entry(self):
         self.wiz_scan_picking.manual_entry = True

--- a/stock_barcodes/views/res_config_settings_views.xml
+++ b/stock_barcodes/views/res_config_settings_views.xml
@@ -26,6 +26,19 @@
                         </div>
                     </div>
                 </div>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-12 col-lg-6 o_setting_box" title="Track pending products at the picking wizard">
+                        <div class="o_setting_left_pane">
+                            <field name="group_track_pending_products_picking_barcode_wizard"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="group_track_pending_products_picking_barcode_wizard"/>
+                            <div class="text-muted">
+                               Add table to track pending products at picking stock wizard
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </field>
     </record>

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -22,6 +22,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
     )
     pending_moves = fields.Html(
         compute="_compute_pending_move",
+        groups="stock_barcodes.group_track_pending_products_picking_barcode"
     )
     candidate_picking_ids = fields.One2many(
         comodel_name='wiz.candidate.picking',

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -89,8 +89,13 @@
                 <field name="picking_product_qty"/>
             </field>
             <xpath expr="//field[@name='scan_log_ids']/.." position="before">
-                <group name="pending_operations" string="Pending operations" attrs="{'invisible': [('picking_id', '=', False)]}">
-                    <field name="pending_moves" nolabel="1">
+                <group name="pending_operations"
+                       string="Pending operations"
+                       attrs="{'invisible': [('picking_id', '=', False)]}"
+                       groups="stock_barcodes.group_track_pending_products_picking_barcode">
+                    <field name="pending_moves"
+                           nolabel="1"
+                    >
                     </field>
                 </group>
             </xpath>

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -88,6 +88,12 @@
             <field name="product_qty" position="after">
                 <field name="picking_product_qty"/>
             </field>
+            <xpath expr="//field[@name='scan_log_ids']/.." position="before">
+                <group name="pending_operations" string="Pending operations" attrs="{'invisible': [('picking_id', '=', False)]}">
+                    <field name="pending_moves" nolabel="1">
+                    </field>
+                </group>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
:sparkles: This PR adds a table at the stock_barcodes_read_picking wizard to track pending products in an easier way.
I tried to do it first with an onchange method, but the quantity_done view was not refreshed. To overcome this, I have simulated a table with an html field that does not have this problem. 
If someone comes up with a better solution, it will be welcome. :slightly_smiling_face: 