### PR TITLE
[IMP] stock_barcodes

### DIFF
--- a/base_gs1_barcode/models/gs1_barcode.py
+++ b/base_gs1_barcode/models/gs1_barcode.py
@@ -161,7 +161,7 @@ class GS1Barcode(models.Model):
                             ai, position))
 
                 position += len(groups['value'])
-                results[ai] = groups['value'].replace(separator, '')
+                results[ai] = groups['value'].replace(separator, '').strip()
                 if types[ai] == 'numeric':
                     results[ai] = int(results[ai])
                     if 'decimal' in groups:

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -91,6 +91,9 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             self.location_id if out_move else self.picking_id.location_id)
         location_dest_id = (
             self.picking_id.location_dest_id if out_move else self.location_id)
+        location_dest_id = location_dest_id.get_putaway_strategy(
+            self.product_id
+        ) or location_dest_id
         return {
             'picking_id': self.picking_id.id,
             'move_id': candidate_move.id,

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -95,7 +95,9 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             'picking_id': self.picking_id.id,
             'move_id': candidate_move.id,
             'qty_done': available_qty,
-            'product_uom_id': self.product_id.uom_po_id.id,
+            'product_uom_id':
+                self.product_id.uom_po_id.id if not self.packaging_id
+                else self.packaging_id.product_uom_id.id,
             'product_id': self.product_id.id,
             'location_id': location_id.id,
             'location_dest_id': location_dest_id.id,

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -89,12 +89,15 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         out_move = candidate_move.picking_code == 'outgoing'
         location_id = (
             self.location_id if out_move else self.picking_id.location_id)
+        quants = self.env["stock.quant"]._gather(
+            self.product_id, location_id, lot_id=self.lot_id, strict=False
+        )
         location_dest_id = (
             self.picking_id.location_dest_id if out_move else self.location_id)
         location_dest_id = location_dest_id.get_putaway_strategy(
             self.product_id
         ) or location_dest_id
-        return {
+        vals = {
             'picking_id': self.picking_id.id,
             'move_id': candidate_move.id,
             'qty_done': available_qty,
@@ -107,6 +110,13 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             'lot_id': self.lot_id.id,
             'lot_name': self.lot_id.name,
         }
+        if quants:
+            reserved_quant = quants[0]
+            vals.update({
+                'location_id': reserved_quant.location_id.id,
+                'owner_id': reserved_quant.owner_id.id or False,
+            })
+        return vals
 
     def _states_move_allowed(self):
         move_states = ['assigned']

--- a/stock_barcodes_gs1/wizard/stock_barcodes_read.py
+++ b/stock_barcodes_gs1/wizard/stock_barcodes_read.py
@@ -48,7 +48,11 @@ class WizStockBarcodesRead(models.AbstractModel):
         if product_barcode:
             product = self.env['product.product'].search(
                 self._barcode_domain(product_barcode))
-            if not product:
+            if not product and not package_barcode:
+                # If we did not found a product and we have not a package, maybe we
+                # can try to use this product barcode as a packaging barcode
+                package_barcode = product_barcode
+            elif not product:
                 self._set_messagge_info(
                     'not_found', _('Barcode for product not found'))
                 return False
@@ -72,7 +76,10 @@ class WizStockBarcodesRead(models.AbstractModel):
         if lot_barcode and self.product_id.tracking != 'none':
             self.process_lot(barcode_decoded)
             processed = True
-        if product_qty:
+        if product_qty and package_barcode:
+            # If we have processed a package, we need to multiply it
+            self.product_qty = self.product_qty * product_qty
+        elif product_qty:
             self.product_qty = product_qty
         if not self.product_qty:
             # This could happen with double GS1-128 barcodes


### PR DESCRIPTION
This PR tries to make the following changes:

* Use the Packaging unit if defined, not the Purchase
* Multiply the units if package is defined on GS1 (it was replaced)
* Try to find the Product code as Package code (#342)
* Returns the stripped value, this is important when scanned Code128 codes, as sometimes this kind of characters is added
* Puts the proper destination location using putaway strategies
* Puts the proper origin location using quants

@LoisRForgeFlow 