### PR TITLE
[FIX] stock_barcodes: avoid mixing tracked and untracked quants

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_inventory.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_inventory.py
@@ -138,19 +138,25 @@ class WizStockBarcodesReadInventory(models.TransientModel):
         for quant in quants:
             qty = (qty_to_assign if qty_to_assign <= quant.quantity else
                    max(quant.quantity, 0))
-            self.lot_id = quant.lot_id
+            self.with_context(keep_auto_lot=True).lot_id = quant.lot_id
             self.product_qty = qty if qty > 0.0 else 0.0
             self._add_inventory_line()
             qty_to_assign -= qty
         if qty_to_assign:
-            self.lot_id = quants[-1:].lot_id
+            self.with_context(keep_auto_lot=True).lot_id = quants[-1:].lot_id
             self.product_qty = qty_to_assign
             self._add_inventory_line()
 
     @api.onchange("product_id")
     def _onchange_product_id(self):
+        self.lot_id = False
         self.auto_lot = self._default_auto_lot()
 
     @api.onchange("lot_id")
     def _onchange_lot_id(self):
-        self.auto_lot = False
+        if self.lot_id and not self.env.context.get("keep_auto_lot"):
+            self.auto_lot = False
+
+    @api.onchange("manual_entry")
+    def _onchange_manual_entry(self):
+        self.auto_lot = self._default_auto_lot()

--- a/stock_barcodes/wizard/stock_barcodes_read_inventory.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_inventory.py
@@ -124,6 +124,12 @@ class WizStockBarcodesReadInventory(models.TransientModel):
         """
         quants = self.env["stock.quant"]._gather(
             self.product_id, self.location_id)
+        # If the product changed from untracked to tracked we need to avoid to
+        # distribute quantities to possible quants with no lot, as those should
+        # be corrected with the inventory. For example with remanent negative
+        # quants.
+        if self.product_id.tracking != 'none':
+            quants = quants.filtered("lot_id")
         if not quants:
             self._set_messagge_info(
                 'not_found', _('There is no lots to assign quantities'))
@@ -131,7 +137,7 @@ class WizStockBarcodesReadInventory(models.TransientModel):
         qty_to_assign = self.product_qty
         for quant in quants:
             qty = (qty_to_assign if qty_to_assign <= quant.quantity else
-                   quant.quantity)
+                   max(quant.quantity, 0))
             self.lot_id = quant.lot_id
             self.product_qty = qty if qty > 0.0 else 0.0
             self._add_inventory_line()


### PR DESCRIPTION
Using the auto lot feature in the inventory scanning we want to avoid
distributing quantities to quants with no lot if the products if the
product change from untracked to tracked.

cc @Tecnativa TT31267
