### PR TITLE
[FIX] stock_picking_product_barcode_report: import order

### DIFF
--- a/stock_picking_product_barcode_report/__init__.py
+++ b/stock_picking_product_barcode_report/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Carlos Roca <carlos.roca@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import wizard
 from . import controllers
 from . import models
+from . import wizard


### PR DESCRIPTION
When updating the addon after https://github.com/OCA/stock-logistics-barcode/pull/328, if the database had any transient record of the `stock.picking.print` model, the update failed with:

    psycopg2.errors.UndefinedColumn: column res_company.barcode_default_report does not exist

To fix that problem, import wizard after models.

@Tecnativa TT28969