### PR TITLE
[14.0] [FIX] fix UI, hide barcode field on template when having variants

### DIFF
--- a/barcodes_generator_product/__manifest__.py
+++ b/barcodes_generator_product/__manifest__.py
@@ -14,6 +14,7 @@
     "license": "AGPL-3",
     "depends": ["barcodes_generator_abstract", "product"],
     "data": ["views/view_product_product.xml", "views/view_product_template.xml"],
+    "maintainers": ["legalsylvain"],
     "demo": [
         "demo/res_users.xml",
         "demo/barcode_rule.xml",

--- a/barcodes_generator_product/views/view_product_product.xml
+++ b/barcodes_generator_product/views/view_product_product.xml
@@ -56,4 +56,56 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             </field>
         </field>
     </record>
+
+    <record id="product_variant_easy_edit_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
+        <field name="arch" type="xml">
+            <field name="barcode" position="before">
+                <field
+                    name="barcode_rule_id"
+                    domain="[('generate_model', '=', 'product.product')]"
+                    groups="barcodes_generator_abstract.generate_barcode"
+                    colspan="2"
+                />
+                <field name="generate_type" invisible="1" />
+                <field
+                    name="barcode_base"
+                    attrs="{
+                    'invisible': [('barcode_rule_id', '=', False)],
+                    'readonly': [('generate_type', '!=', 'manual')]}"
+                    groups="barcodes_generator_abstract.generate_barcode"
+                    colspan="2"
+                />
+                <button
+                    name="generate_base"
+                    type="object"
+                    string="Generate Base (Using Sequence)"
+                    attrs="{'invisible': ['|',
+                    ('generate_type', '!=', 'sequence'),
+                    ('barcode_base', '!=', 0)]}"
+                    groups="barcodes_generator_abstract.generate_barcode"
+                    colspan="2"
+                />
+            </field>
+            <field name="barcode" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'readonly': [('generate_type', '=', 'sequence')]}</attribute>
+            </field>
+            <field name="barcode" position="after">
+                <button
+                    name="generate_barcode"
+                    type="object"
+                    string="Generate Barcode (Using Barcode Rule)"
+                    attrs="{'invisible': ['|',
+                            ('barcode_rule_id', '=', False),
+                            ('barcode_base', '=', 0)]}"
+                    groups="barcodes_generator_abstract.generate_barcode"
+                    colspan="2"
+                />
+            </field>
+        </field>
+    </record>
+
 </odoo>

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -16,12 +16,17 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     domain="[('generate_model', '=', 'product.product')]"
                     groups="barcodes_generator_abstract.generate_barcode"
                     colspan="2"
+                    attrs="{'invisible': [('product_variant_count', '&gt;', 1)]}"
                 />
                 <field name="generate_type" invisible="1" />
                 <field
                     name="barcode_base"
                     attrs="{
-                    'invisible': [('barcode_rule_id', '=', False)],
+                    'invisible': [
+                         '|',
+                         ('barcode_rule_id', '=', False),
+                         ('product_variant_count', '&gt;', 1)
+                         ],
                     'readonly': [('generate_type', '!=', 'manual')]}"
                     groups="barcodes_generator_abstract.generate_barcode"
                     colspan="2"
@@ -30,26 +35,31 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     name="generate_base"
                     type="object"
                     string="Generate Base (Using Sequence)"
-                    attrs="{'invisible': ['|',
+                    attrs="{'invisible': ['|', '|',
                     ('generate_type', '!=', 'sequence'),
-                    ('barcode_base', '!=', 0)]}"
+                    ('barcode_base', '!=', 0),
+                    ('product_variant_count', '&gt;', 1),
+                    ]}"
                     groups="barcodes_generator_abstract.generate_barcode"
                     colspan="2"
                 />
             </field>
             <field name="barcode" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'readonly': [('generate_type', '=', 'sequence')]}</attribute>
+                <attribute name="attrs">{
+                    'readonly': [('generate_type', '=', 'sequence')],
+                    'invisible': [('product_variant_count', '&gt;', 1)]
+                    }</attribute>
             </field>
             <field name="barcode" position="after">
                 <button
                     name="generate_barcode"
                     type="object"
                     string="Generate Barcode (Using Barcode Rule)"
-                    attrs="{'invisible': ['|',
+                    attrs="{'invisible': ['|', '|',
                             ('barcode_rule_id', '=', False),
-                            ('barcode_base', '=', 0)]}"
+                            ('barcode_base', '=', 0),
+                            ('product_variant_count', '&gt;', 1)
+                            ]}"
                     groups="barcodes_generator_abstract.generate_barcode"
                     colspan="2"
                 />


### PR DESCRIPTION
@legalsylvain In native Odoo the barcode field is hidden on varianted template
Restore this feature on barcode field and apply it on related barcode field of this module