### PR TITLE
[14.0][FIX] product_supplierinfo_barcode: barcode field not available on purchase tree view on v14

### DIFF
--- a/product_supplierinfo_barcode/readme/CONTRIBUTORS.rst
+++ b/product_supplierinfo_barcode/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Lorenzo Battistini (https://takobi.online)
 * Helly kapatel <helly.kapatel@initos.com>
+* Eric Antones <eantones@nuobit.com>

--- a/product_supplierinfo_barcode/views/product_views.xml
+++ b/product_supplierinfo_barcode/views/product_views.xml
@@ -14,4 +14,15 @@
             </field>
         </field>
     </record>
+
+    <record id="product_supplierinfo_tree_view2" model="ir.ui.view">
+        <field name="name">product.supplierinfo.tree.view2.barcode</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="purchase.product_supplierinfo_tree_view2" />
+        <field name="arch" type="xml">
+            <field name="product_code" position="after">
+                <field name="barcode" optional="hide" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
The barcode field is not available on supplier info tree view and since in v14 you have no access to form view then the barcode is not available to fill up.
