### PR TITLE
[14.0][FIX] stock_barcodes: make available the action of reading barcodes.

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -57,7 +57,7 @@
                     <field
                         name="_barcode_scanned"
                         widget="barcode_handler"
-                        invisible="1"
+                        invisible="0"
                     />
                     <group>
                         <field

--- a/stock_barcodes/wizard/stock_production_lot_views.xml
+++ b/stock_barcodes/wizard/stock_production_lot_views.xml
@@ -16,7 +16,7 @@
                         <field
                             name="_barcode_scanned"
                             widget="barcode_handler"
-                            invisible="1"
+                            invisible="0"
                         />
                         <field name="product_id" />
                         <field name="lot_name" />


### PR DESCRIPTION
The field _barcode_scanned has to be visible in order to trigger the action of reading barcodes.

@JoanMForgeFlow
@LoisRForgeFlow