### PR TITLE
[IMP] product_multi_barcode :  Fix conditions for barcode update and creation

### DIFF
--- a/product_multi_barcode/models/product_product.py
+++ b/product_multi_barcode/models/product_product.py
@@ -32,10 +32,11 @@ class ProductProduct(models.Model):
         for product in self:
             if product.barcode_ids:
                 product.barcode_ids[:1].write({"name": product.barcode})
-            if not product.barcode:
-                product.barcode_ids.unlink()
             else:
-                self.env["product.barcode"].create(self._prepare_barcode_vals())
+                if not product.barcode:
+                    product.barcode_ids.unlink()
+                else:
+                    self.env["product.barcode"].create(self._prepare_barcode_vals())
 
     def _prepare_barcode_vals(self):
         self.ensure_one()


### PR DESCRIPTION
When a barcode is assigned to a product and updated.
It will update that barcode in the product and Product Barcode record and as the current code, it runs ahead and tries to create a new product barcode record with the same barcode and it gives a warning, added a fix for that.

Test of https://github.com/OCA/stock-logistics-barcode/pull/388 failed because of this issue.

