### PR TITLE
[ADD] Change functionality generate barcode product.

### DIFF
--- a/barcodes_generator_product/__manifest__.py
+++ b/barcodes_generator_product/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Generate Barcodes for Products",
     "summary": "Generate Barcodes for Products (Templates and Variants)",
-    "version": "14.0.1.1.0",
+    "version": "14.0.2.1.0",
     "category": "Tools",
     "author": "GRAP, La Louve, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-barcode",

--- a/barcodes_generator_product/models/product_product.py
+++ b/barcodes_generator_product/models/product_product.py
@@ -9,3 +9,9 @@ from odoo import models
 class ProductProduct(models.Model):
     _name = "product.product"
     _inherit = ["product.product", "barcode.generate.mixin"]
+
+    def write(self, vals):
+        barcode_rule_id = self.mapped("product_tmpl_id.barcode_rule_id")
+        if barcode_rule_id:
+            vals["barcode_rule_id"] = barcode_rule_id[0]
+        return super(ProductProduct, self).write(vals)

--- a/barcodes_generator_product/models/product_template.py
+++ b/barcodes_generator_product/models/product_template.py
@@ -11,7 +11,7 @@ class ProductTemplate(models.Model):
 
     # Related to display product product information if is_product_variant
     barcode_rule_id = fields.Many2one(
-        related="product_variant_ids.barcode_rule_id",
+        # related="product_variant_ids.barcode_rule_id",
         string="Barcode Rule",
         readonly=False,
         comodel_name="barcode.rule",
@@ -28,6 +28,11 @@ class ProductTemplate(models.Model):
         readonly=True,
         related="product_variant_ids.barcode_rule_id.generate_type",
     )
+
+    def action_generate_barcode(self):
+        self.ensure_one()
+        self.product_variant_ids.filtered(lambda k: not k.barcode).generate_base()
+        self.product_variant_ids.filtered(lambda k: not k.barcode).generate_barcode()
 
     # View Section
     def generate_base(self):
@@ -56,3 +61,11 @@ class ProductTemplate(models.Model):
         if related_vals:
             template.write(related_vals)
         return template
+
+    def write(self, vals):
+        res = super().write(vals)
+
+        if "barcode_rule_id" in vals:
+            self.product_variant_ids.write({"barcode_rule_id": self.barcode_rule_id})
+
+        return res

--- a/barcodes_generator_product/tests/test_barcodes_generator_product.py
+++ b/barcodes_generator_product/tests/test_barcodes_generator_product.py
@@ -13,6 +13,15 @@ class Tests(TransactionCase):
         super().setUp()
         self.template_obj = self.env["product.template"]
         self.product_obj = self.env["product.product"]
+        self.sequence_test_1 = self.env["ir.sequence"].create(
+            {
+                "name": "Sequence test 1",
+                "implementation": "standard",
+                "padding": 4,
+                "number_increment": 1,
+                "number_next_actual": 1,
+            }
+        )
         self.barcode_rule = self.env["barcode.rule"].create(
             {
                 "name": "Product Rule Test",
@@ -20,10 +29,26 @@ class Tests(TransactionCase):
                     "barcodes.default_barcode_nomenclature"
                 ).id,
                 "type": "product",
-                "sequence": 999,
+                "sequence": self.sequence_test_1.id,
                 "encoding": "ean13",
                 "pattern": "20.....{NNNDD}",
                 "generate_type": "manual",
+                "generate_model": "product.product",
+            }
+        )
+        self.barcode_rule_2 = self.env["barcode.rule"].create(
+            {
+                "name": "Product Rule Test",
+                "barcode_nomenclature_id": self.env.ref(
+                    "barcodes.default_barcode_nomenclature"
+                ).id,
+                "type": "product",
+                "sequence": 0,
+                "sequence_id": self.sequence_test_1.id,
+                "encoding": "ean13",
+                "pattern": "12345678....",
+                "padding": 4,
+                "generate_type": "sequence",
                 "generate_model": "product.product",
             }
         )
@@ -72,3 +97,57 @@ class Tests(TransactionCase):
                 self.product_variant_1.barcode_base,
             ),
         )
+
+    def test_03_assigned_barcode_variants(self):
+        self.template_multi = self.template_obj.create(
+            {
+                "name": "Template Multi Variant",
+            }
+        )
+        self.product_variant_1 = self.product_obj.create(
+            {
+                "name": "Variant 1",
+                "product_tmpl_id": self.template_multi.id,
+            }
+        )
+        self.product_variant_2 = self.product_obj.create(
+            {
+                "name": "Variant 2",
+                "product_tmpl_id": self.template_multi.id,
+            }
+        )
+        self.template_multi.write({"barcode_rule_id": self.barcode_rule_2.id})
+
+        self.assertEqual(
+            self.product_variant_1.barcode_rule_id, self.template_multi.barcode_rule_id
+        )
+        self.assertEqual(
+            self.product_variant_2.barcode_rule_id, self.template_multi.barcode_rule_id
+        )
+
+    def test_04_assigned_barcode_variants(self):
+        self.template_multi = self.template_obj.create(
+            {
+                "name": "Template Multi Variant",
+            }
+        )
+        self.product_variant_1 = self.product_obj.create(
+            {
+                "name": "Variant 1",
+                "product_tmpl_id": self.template_multi.id,
+                "barcode": 123456,
+            }
+        )
+        self.product_variant_2 = self.product_obj.create(
+            {
+                "name": "Variant 1",
+                "product_tmpl_id": self.template_multi.id,
+            }
+        )
+        self.template_multi.write({"barcode_rule_id": self.barcode_rule_2.id})
+        self.template_multi.action_generate_barcode()
+
+        self.assertEqual(self.product_variant_1.barcode, "123456")
+        self.assertNotEqual(self.product_variant_2.barcode, False)
+
+        self.registry.reset_changes()

--- a/barcodes_generator_product/views/view_product_product.xml
+++ b/barcodes_generator_product/views/view_product_product.xml
@@ -16,6 +16,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     domain="[('generate_model', '=', 'product.product')]"
                     groups="barcodes_generator_abstract.generate_barcode"
                     colspan="2"
+                    readonly="1"
                 />
                 <field name="generate_type" invisible="1" />
                 <field

--- a/barcodes_generator_product/views/view_product_template.xml
+++ b/barcodes_generator_product/views/view_product_template.xml
@@ -16,7 +16,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     domain="[('generate_model', '=', 'product.product')]"
                     groups="barcodes_generator_abstract.generate_barcode"
                     colspan="2"
-                    attrs="{'invisible': [('product_variant_count', '&gt;', 1)]}"
+                />
+                <button
+                    name="action_generate_barcode"
+                    type="object"
+                    string="Generate Barcodes"
+                    groups="barcodes_generator_abstract.generate_barcode"
                 />
                 <field name="generate_type" invisible="1" />
                 <field
@@ -49,20 +54,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     'readonly': [('generate_type', '=', 'sequence')],
                     'invisible': [('product_variant_count', '&gt;', 1)]
                     }</attribute>
-            </field>
-            <field name="barcode" position="after">
-                <button
-                    name="generate_barcode"
-                    type="object"
-                    string="Generate Barcode (Using Barcode Rule)"
-                    attrs="{'invisible': ['|', '|',
-                            ('barcode_rule_id', '=', False),
-                            ('barcode_base', '=', 0),
-                            ('product_variant_count', '&gt;', 1)
-                            ]}"
-                    groups="barcodes_generator_abstract.generate_barcode"
-                    colspan="2"
-                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
n this PR the main modifications are:

`barcode_rule_id` is not related with the field `product.product` because was inducing wrong behaviour during variants creation when the rule was not set as `automatic`. This functionality has been achieved modifying the `write` function to assure that if you change anything in the `product.template` it is changed in the `product.product`. The main drawback is that the `barcode_rule_id` in the `product.prouduct` is now `readonly`. 
A new action `generate_barcode` is added to generate a barcode in a product with variants when you add more variants after the barcode is generated.
