### PR TITLE
[FIX][12.0] stock_barcodes_supplierinfo ignore possible lot scan

### DIFF
--- a/stock_barcodes_supplierinfo/wizard/stock_barcodes_read.py
+++ b/stock_barcodes_supplierinfo/wizard/stock_barcodes_read.py
@@ -11,11 +11,12 @@ class WizStockBarcodesRead(models.AbstractModel):
             # also search by supplier barcode
             product = self.env['product.product'].search([
                 ('seller_ids.barcode', '=', barcode)])
-            if len(product) > 1:
-                self._set_messagge_info(
-                    'more_match', _('More than one product found'))
+            if product:
+                if len(product) > 1:
+                    self._set_messagge_info(
+                        'more_match', _('More than one product found'))
+                    return
+                self.action_product_scaned_post(product)
+                self.action_done()
                 return
-            self.action_product_scaned_post(product)
-            self.action_done()
-            return
         return super(WizStockBarcodesRead, self).process_barcode(barcode)


### PR DESCRIPTION
In case of lot scan, the current function do not find the product with this barcode and return ignoring the scanned barcode.
This PR fix this.