### PR TITLE
[13.0][FIX] stock_barcodes: several small adjustments

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -165,6 +165,10 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             return False
         if not self.todo_line_ids:
             self.fill_todo_records()
+        # When scanning all information in one step (e.g. using GS-1), the
+        # status and qty processed might have not been update, we ensure it
+        # invalidating the cache.
+        self.todo_line_ids.invalidate_cache()
         self.todo_line_id = (
             forced_todo_line
             or self.todo_line_ids.filtered(lambda t: t._origin.state == "pending")[:1]
@@ -334,7 +338,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                         and l.product_id == self.product_id
                     )
                 )
-                if candidate_lines:
+                if candidate_lines and self.location_id:
                     sml_vals.update({"location_id": self.location_id.id})
         if not candidate_lines:
             location_dest_option = self.option_group_id.option_ids.filtered(
@@ -347,7 +351,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                         and l.product_id == self.product_id
                     )
                 )
-                if candidate_lines:
+                if candidate_lines and self.location_dest_id:
                     sml_vals.update({"location_dest_id": self.location_dest_id.id})
         return candidate_lines
 
@@ -746,7 +750,10 @@ class WizCandidatePicking(models.TransientModel):
         picking = self.env["stock.picking"].browse(
             self.env.context.get("picking_id", False)
         )
-        picking.button_validate()
+        res = picking.button_validate()
+        if isinstance(res, dict):
+            # backorder wizard
+            return res
         return self.env.ref("stock_barcodes.action_stock_barcodes_action").read()[0]
 
     def action_open_picking(self):

--- a/stock_barcodes/wizard/stock_barcodes_read_todo_view.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo_view.xml
@@ -127,7 +127,7 @@
                                         context="{'wiz_barcode_id': parent.id}"
                                         accesskey="3"
                                     >
-                                    Force
+                                    Done
                                     </button>
                                 </div>
                                 <div class="col-3">

--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -245,6 +245,26 @@
                                 </div>
                             </group>
                             <group
+                                name="option_qty_info"
+                                attrs="{'invisible': ['|', ('product_id', '=', False),'|', ('is_manual_qty', '=', True), ('manual_entry', '=', True)]}"
+                                col="1"
+                            >
+                                <div class="mt4">
+                                    <strong class="d-none d-sm-block">Total Qty</strong>
+                                    <span
+                                        class="fa fa-hashtag d-sm-none oe_span_small_icon"
+                                    />
+                                    <field
+                                        name="product_qty"
+                                        attrs="{'readonly': [('manual_entry', '=', False)]}"
+                                        force_save="1"
+                                        style="width:85%"
+                                        class="h5"
+                                    />
+                                </div>
+                            </group>
+
+                            <group
                                 name="option_qty"
                                 attrs="{'invisible': ['|', ('product_id', '=', False),'&amp;', ('is_manual_qty', '=', False), ('manual_entry', '=', False)]}"
                                 col="1"
@@ -255,7 +275,7 @@
                                         name="total_qty_header"
                                     >
                                         <div>
-                                            <span>Total qty</span>
+                                            <span>Total Qty</span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
* When a picking is processed partially it was not
      posible to validate it because the backorder wizard
      was captured and never returned to the user.
* Only update sml locations when there is a location
      to update, otherwise constraints for non null values
      could raise.
* Invalidate cache of todo lines when determining
      next action to do to ensure that line status is
      updated.
* Reword string in button from "Force" to "Done"
      as it was a bit misleading. Actually, in spanish
      translation it was already being translated to
      "Hecho" ("Done").

Extra, to be discussed, in a separate commit for now:

* show quantity even when not editable.

Desktop view:

![image](https://user-images.githubusercontent.com/23449160/177976722-1c89ffd6-e4e6-4995-a856-705ed1b863c4.png)

Mobile view:
![image](https://user-images.githubusercontent.com/23449160/177976829-55f7b5ca-7aa3-4194-975f-3e06ed5534b7.png)

@ForgeFlow

