### PR TITLE
[14.0][FIX] stock_barcodes_gs1: Do action_confirm after gs1 is readed instead of action_done

### DIFF
--- a/stock_barcodes_gs1/wizard/stock_barcodes_read.py
+++ b/stock_barcodes_gs1/wizard/stock_barcodes_read.py
@@ -103,7 +103,7 @@ class WizStockBarcodesRead(models.AbstractModel):
         if processed:
             if not self.check_option_required():
                 return False
-            self.action_done()
+            self.action_confirm()
             self._set_messagge_info("success", _("Barcode read correctly"))
             return True
         return super().process_barcode(barcode)


### PR DESCRIPTION
Cherry pick from https://github.com/OCA/stock-logistics-barcode/commit/d8d40fdd47842c212c635f4cc5b10ca1e7e78239

ping @rousseldenis @yehebihr

cc @Tecnativa