### PR TITLE
[13.0][FIX] stock_barcodes: do not use PO UoM by default

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -253,7 +253,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             "picking_id": picking.id,
             "move_id": candidate_move.id,
             "qty_done": available_qty,
-            "product_uom_id": self.product_id.uom_po_id.id
+            "product_uom_id": candidate_move.product_uom.id or self.product_id.uom_id.id
             if not self.packaging_id
             else self.packaging_id.product_uom_id.id,
             "product_id": self.product_id.id,


### PR DESCRIPTION
When creating new stock move lines, we should use the UoM in the
move, if any, or the default UoM of the product.

Backport of #430 

cc @pedrobaeza @sergio-teruel 