### PR TITLE
[13.0][FIX] stock_barcodes: remove last scan do not revert last action.

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -453,8 +453,9 @@ class WizStockBarcodesRead(models.AbstractModel):
             self.product_qty = 1.0
         if not self.check_done_conditions():
             return False
-        _logger.info("Add scanned log barcode:{}".format(self.barcode))
-        self._add_read_log()
+        if not self.env.context.get("_stock_barcodes_skip_read_log"):
+            _logger.info("Add scanned log barcode:{}".format(self.barcode))
+            self._add_read_log()
         return True
 
     def action_cancel(self):

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -438,7 +438,12 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             not self.option_group_id.code == "REL"
             and not self.env.context.get("force_create_move", False)
             and not self.env.context.get("manual_picking", False)
-            and available_qty > max_quantity
+            and float_compare(
+                available_qty,
+                max_quantity,
+                precision_rounding=self.product_id.uom_id.rounding,
+            )
+            > 0
         ):
             self._set_messagge_info(
                 "more_match", _("Quantities scanned are higher than necessary")
@@ -553,7 +558,12 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         res = super().check_done_conditions()
         if (
             self.picking_type_code != "incoming"
-            and self.product_qty > self.qty_available
+            and float_compare(
+                self.product_qty,
+                self.qty_available,
+                precision_rounding=self.product_id.uom_id.rounding,
+            )
+            > 0
             and not self.env.context.get("force_create_move", False)
             and not self.option_group_id.allow_negative_quant
         ):

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -214,7 +214,11 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         self.picking_product_qty = move_line.qty_done
 
     def action_done(self):
-        res = super().action_done()
+        # Skip read log creation to be able to pass log_detail when available.
+        res = super(
+            WizStockBarcodesReadPicking,
+            self.with_context(_stock_barcodes_skip_read_log=True),
+        ).action_done()
         if res:
             move_dic = self._process_stock_move_line()
             if move_dic:
@@ -224,7 +228,13 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                 if self.env.context.get("force_create_move"):
                     self.move_line_ids.barcode_scan_state = "done_forced"
                 self.determine_todo_action()
+            # Now we can add read log with details.
+            _logger.info("Add scanned log barcode:{}".format(self.barcode))
+            self._add_read_log(log_detail=move_dic)
             return bool(move_dic)
+        # Add read log normally.
+        _logger.info("Add scanned log barcode:{}".format(self.barcode))
+        self._add_read_log()
         return res
 
     def action_manual_entry(self):
@@ -582,15 +592,19 @@ class WizStockBarcodesReadPicking(models.TransientModel):
     def remove_scanning_log(self, scanning_log):
         for log in scanning_log:
             for log_scan_line in log.log_line_ids:
-                if log_scan_line.move_line_id.state not in ["assigned", "confirmed"]:
+                sml = log_scan_line.move_line_id
+                if sml.state not in ["draft", "assigned", "confirmed"]:
                     raise ValidationError(
                         _(
-                            "You can not remove an entry linked to a stock move "
-                            "line in state assigned or confirmed"
+                            "You cannot remove an entry linked to a operation "
+                            "in state new, assigned or confirmed"
                         )
                     )
-                qty = log_scan_line.move_line_id.qty_done - log_scan_line.product_qty
+                qty = sml.qty_done - log_scan_line.product_qty
                 log_scan_line.move_line_id.qty_done = max(qty, 0.0)
+                if sml.state == "draft" and sml.move_id.quantity_done == 0.0:
+                    # This move has been created by the last scan, remove it.
+                    sml.move_id.unlink()
             self.picking_product_qty = sum(
                 log.log_line_ids.mapped("move_line_id.move_id.quantity_done")
             )


### PR DESCRIPTION
In pickings, the scan log was always generated without details of the move lines modified/created. Without this information in the log removing the log was dong nothing else than just that, removing the log; leaving the last operation still reflected in the picking.

Also, when the picking was a draft one, the stock move line and the stock move could have been created by the scan itself, so we
need to remove it in that case, reverting the action would leave the stock move there that could be validated by mistake.

@ForgeFlow

cc @pedrobaeza @sergio-teruel

Backport of #432 