### PR TITLE
[14.0][IMP] stock_barcodes: Clean wizard values after the move to do has been reset

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_todo.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo.py
@@ -176,6 +176,7 @@ class WizStockBarcodesReadTodo(models.TransientModel):
         self.state = "pending"
         self.line_ids.barcode_scan_state = "pending"
         self.line_ids.qty_done = 0.0
+        self.wiz_barcode_id.action_clean_values()
         self.wiz_barcode_id.determine_todo_action()
 
     def action_back_line(self):


### PR DESCRIPTION
cc @Tecnativa

Commit from v13 (https://github.com/OCA/stock-logistics-barcode/pull/438/commits/cbd75aae19821679d55e426eb9ac882c7427e7fb)

ping @carlosdauden @chienandalu 