### PR TITLE
[13.0] [FIX] stock_barcodes

### DIFF
--- a/stock_barcodes/data/stock_barcodes_option.xml
+++ b/stock_barcodes/data/stock_barcodes_option.xml
@@ -118,7 +118,7 @@
             <field name="barcode_guided_mode" />
             <field name="show_pending_moves">True</field>
             <field name="confirmed_moves">False</field>
-            <field name="source_pending_moves">move_line_ids</field>
+            <field name="source_pending_moves">move_lines</field>
             <field name="fill_fields_from_lot">False</field>
         </record>
         <record

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -182,13 +182,13 @@ class TestStockBarcodesPicking(TestStockBarcodes):
         wiz_scan_picking = self.wiz_scan_picking.with_context(force_create_move=True)
         wiz_scan_picking.manual_entry = True
         self.action_barcode_scanned(wiz_scan_picking, "8480000723208")
-        sml = self.picking_in_01.move_line_ids.filtered(
+        sml = self.picking_in_01.move_lines.filtered(
             lambda x: x.product_id == self.product_wo_tracking
         )
         self.assertEqual(wiz_scan_picking.product_qty, 0.0)
         wiz_scan_picking.product_qty = 12.0
         wiz_scan_picking.action_confirm()
-        self.assertEqual(sml.qty_done, 12.0)
+        self.assertEqual(sml.quantity_done, 12.0)
 
     def test_barcode_from_operation(self):
         picking_out_3 = self.picking_out_01.copy()

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -142,7 +142,7 @@ class TestStockBarcodesPicking(TestStockBarcodes):
     def test_picking_wizard_scan_product(self):
         wiz_scan_picking = self.wiz_scan_picking.with_context(force_create_move=True)
         self.action_barcode_scanned(wiz_scan_picking, "8480000723208")
-        sml = self.picking_in_01.move_line_ids.filtered(
+        sml = self.picking_in_01.move_line_nosuggest_ids.filtered(
             lambda x: x.product_id == self.product_wo_tracking
         )
         self.assertEqual(sml.qty_done, 1.0)

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -259,6 +259,10 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             and sum(self.package_id.quant_ids.mapped("quantity")) <= self.product_qty
         ):
             self.result_package_id = self.package_id
+        location_dest_id = (
+            self.location_dest_id._get_putaway_strategy(self.product_id)
+            or self.location_dest_id
+        )
         vals = {
             "picking_id": picking.id,
             "move_id": candidate_move.id,
@@ -268,7 +272,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             else self.packaging_id.product_uom_id.id,
             "product_id": self.product_id.id,
             "location_id": self.location_id.id,
-            "location_dest_id": self.location_dest_id.id,
+            "location_dest_id": location_dest_id.id,
             "lot_id": self.lot_id.id,
             "lot_name": self.lot_id.name,
             "barcode_scan_state": "done_forced",

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -329,7 +329,10 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         return True
 
     def _get_candidate_stock_move_lines(self, moves_todo, sml_vals):
-        candidate_lines = moves_todo.mapped("move_line_ids").filtered(
+        field_lines = "move_line_ids"
+        if not self.picking_id.show_reserved:
+            field_lines = "move_line_nosuggest_ids"
+        candidate_lines = moves_todo.mapped(field_lines).filtered(
             lambda l: (
                 # l.picking_id == self.picking_id and
                 l.location_id == self.location_id
@@ -342,7 +345,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                 lambda op: op.field_name == "location_id"
             )
             if not location_option.forced:
-                candidate_lines = moves_todo.mapped("move_line_ids").filtered(
+                candidate_lines = moves_todo.mapped(field_lines).filtered(
                     lambda l: (
                         l.location_dest_id == self.location_dest_id
                         and l.product_id == self.product_id
@@ -355,7 +358,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                 lambda op: op.field_name == "location_dest_id"
             )
             if not location_dest_option.forced:
-                candidate_lines = moves_todo.mapped("move_line_ids").filtered(
+                candidate_lines = moves_todo.mapped(field_lines).filtered(
                     lambda l: (
                         l.location_id == self.location_id
                         and l.product_id == self.product_id


### PR DESCRIPTION
When testing stock barcodes I found some errors:

- Pending moves where used, and it was confusing when using purchase orders, as the first element was not shown
- Changing the kind of field for INs, as in purchases, we don't know the lot, so we should need to use stock.moves not stock.move.line
- Putaway strategy was not being applied

@etobella @LoisRForgeFlow @sergio-teruel 