### PR TITLE
[14.0] [FIX] stock_barcodes: use action_put_in_pack instead of put_in_pack

### DIFF
--- a/stock_barcodes/models/stock_picking.py
+++ b/stock_barcodes/models/stock_picking.py
@@ -40,5 +40,5 @@ class StockPicking(models.Model):
             self.picking_type_id.barcode_option_group_id.auto_put_in_pack
             and not self.move_line_ids.mapped("result_package_id")
         ):
-            self.put_in_pack()
+            self.action_put_in_pack()
         return super().button_validate()

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -128,6 +128,7 @@ class TestStockBarcodesPicking(TestStockBarcodes):
         action = self.picking_out_01.action_barcode_scan()
         self.wiz_scan_picking_out = self.ScanReadPicking.browse(action["res_id"])
 
+
     def test_wiz_picking_values(self):
         self.assertEqual(
             self.wiz_scan_picking.location_id, self.picking_in_01.location_id
@@ -177,7 +178,12 @@ class TestStockBarcodesPicking(TestStockBarcodes):
         self.action_barcode_scanned(wiz_scan_picking, "5420008510489")
         # Package of 5 product units. Already three unit exists
         self.assertEqual(sum(stock_move.move_line_ids.mapped("qty_done")), 8.0)
-
+    
+    
+    def test_action_put_in_pack(self):
+        self.assertTrue(self.picking_in_01.action_put_in_pack())
+        
+    
     def test_picking_wizard_scan_product_manual_entry(self):
         wiz_scan_picking = self.wiz_scan_picking.with_context(force_create_move=True)
         wiz_scan_picking.manual_entry = True

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -177,12 +177,7 @@ class TestStockBarcodesPicking(TestStockBarcodes):
         # Scan a package
         self.action_barcode_scanned(wiz_scan_picking, "5420008510489")
         # Package of 5 product units. Already three unit exists
-        self.assertEqual(sum(stock_move.move_line_ids.mapped("qty_done")), 8.0)
-    
-    
-    def test_action_put_in_pack(self):
-        self.assertTrue(self.picking_in_01.action_put_in_pack())
-        
+        self.assertEqual(sum(stock_move.move_line_ids.mapped("qty_done")), 8.0)       
     
     def test_picking_wizard_scan_product_manual_entry(self):
         wiz_scan_picking = self.wiz_scan_picking.with_context(force_create_move=True)
@@ -455,3 +450,6 @@ class TestStockBarcodesPicking(TestStockBarcodes):
                 ],
             }
         )
+
+    def test_action_put_in_pack(self):
+        self.assertTrue(self.picking_in_01.action_put_in_pack())

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -657,7 +657,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         raise ValidationError(_("No pending lines for this product"))
 
     def action_put_in_pack(self):
-        self.picking_id.put_in_pack()
+        self.picking_id.action_put_in_pack()
 
 
 class WizCandidatePicking(models.TransientModel):
@@ -793,4 +793,4 @@ class WizCandidatePicking(models.TransientModel):
         return picking.with_context(control_panel_hidden=False).get_formview_action()
 
     def action_put_in_pack(self):
-        self.picking_id.put_in_pack()
+        self.picking_id.action_put_in_pack()


### PR DESCRIPTION

**put_in_pack** has been substitued from **action_put_in_pack** from v14.0