### PR TITLE
[14.0][FIX]computed field (qty_done) does not update

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_todo.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo.py
@@ -41,7 +41,7 @@ class WizStockBarcodesReadTodo(models.TransientModel):
     qty_done = fields.Float(
         "Done",
         digits="Product Unit of Measure",
-        readonly=False,
+        readonly=True,
         compute="_compute_qty_done",
         store=True,
     )


### PR DESCRIPTION
In this case the need is to pick out the products from a sale order. The operative is scan the code bar product and if it's correct picks it up.

As you can see in the image.
Wizard window don't update amount done while you are scanning. I have to server 4 units and I've already scanned two but windows still to 0.
If I click in the line opens de window with the correct information.

![imagen](https://user-images.githubusercontent.com/8178160/201962192-592f930d-01f8-4a70-a7f6-49641ea53d67.png)

Even it would be good that the line change the color if the amount demanded is different that amount done.
