### PR TITLE
[14.0] product_multi_barcode: fix muti-company access right issue

### DIFF
--- a/product_multi_barcode/models/product_barcode.py
+++ b/product_multi_barcode/models/product_barcode.py
@@ -56,7 +56,19 @@ class ProductBarcode(models.Model):
                 [("id", "!=", record.id), ("name", "=", record.name)]
             )
             if barcodes:
+                # by default barcode 'shared' between all company (no ir.rule)
+                # so we may not have the access right on the product
+                # note: if you do not want to share the barcode between company
+                # you just need to add a custom ir.rule
+                product = barcodes[0].sudo().product_id
                 raise UserError(
-                    _('The Barcode "%s" already exists for product ' '"%s"')
-                    % (record.name, barcodes[0].product_id.name)
+                    _(
+                        'The Barcode "%(barcode_name)s" already exists for '
+                        'product "%(product_name)s" in the company %(company_name)s'
+                    )
+                    % dict(
+                        barcode_name=record.name,
+                        product_name=product.name,
+                        company_name=product.company_id.name,
+                    )
                 )


### PR DESCRIPTION
Context
In multi company
- add a barcode in company A (for a product that belong to company A)
- then add the same barcode in company B (for a product that belong to company B)

=> you have a access error message instead of a the error message that give the information of the duplicated product barcode.



