### PR TITLE
[14.0][FIX] product_multi_barcode_supplierinfo: an empty barcode can only b..

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.12.0
+_commit: v1.14.2
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
 github_check_license: true
+github_ci_extra_env: {}
 github_enable_codecov: true
 github_enable_makepot: true
 github_enable_stale_action: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/product_multi_barcode_supplierinfo/models/supplierinfo.py
+++ b/product_multi_barcode_supplierinfo/models/supplierinfo.py
@@ -23,7 +23,7 @@ class SupplierInfo(models.Model):
             if rec.barcode_id:
                 rec.barcode = rec.barcode_id.name
             else:
-                rec.barcode = ""
+                rec.barcode = False
 
     def _inverse_barcode_field(self):
         for supplier_info in self:

--- a/product_multi_barcode_supplierinfo/readme/CONTRIBUTORS.rst
+++ b/product_multi_barcode_supplierinfo/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Maria de Luna <maria.de.luna@forgeflow.com>
+* Eric Antones <eantones@nuobit.com>


### PR DESCRIPTION
…e assigned to one supplierinfo when barcode field is "" instead of False (NULL)

The sql constraint https://github.com/OCA/stock-logistics-barcode/blob/bc267289a696e3190e6fea9e39fb552e6f7e14ef/product_supplierinfo_barcode/models/supplierinfo.py#L13-L19 only allows duplicated barcodes if they are NULL (False), it doesn't if they are "".

@mariadforgeflow @LoisRForgeFlow can you please review. Thanks! :-)