### PR TITLE
[16.0][FIX] barcodes_generator_abstract: get the real integer code for all coding types

### DIFF
--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -78,7 +78,7 @@ class BarcodeGenerateMixin(models.AbstractModel):
             if custom_code:
                 custom_code = custom_code.replace("." * padding, str_base)
                 barcode_class = barcode.get_barcode_class(item.barcode_rule_id.encoding)
-                item.barcode = barcode_class(custom_code)
+                item.barcode = barcode_class(custom_code).get_fullcode()
 
     # Custom Section
     @api.model


### PR DESCRIPTION
if you use for example the gs1-128 coding, this coding cannot be saved in odoo directly.

> import barcode
> EAN = barcode.get_barcode_class('gs1_128')
> str(EAN('0000'))
> 'ñ0000'

We have to call the function get_fullcode which is a code that we can save in Odoo.

> import barcode
>  EAN = barcode.get_barcode_class('gs1_128')
>  str(EAN('0000').get_fullcode())
> '0000'