### PR TITLE
product_multi_barcode: remove useless costly dependency

### DIFF
--- a/product_multi_barcode/models/product_barcode.py
+++ b/product_multi_barcode/models/product_barcode.py
@@ -42,7 +42,7 @@ class ProductBarcode(models.Model):
         for rec in self.filtered(lambda x: not x.product_tmpl_id and x.product_id):
             rec.product_tmpl_id = rec.product_id.product_tmpl_id
 
-    @api.depends("product_tmpl_id.product_variant_ids")
+    @api.depends("product_tmpl_id")
     def _compute_product(self):
         for rec in self.filtered(
             lambda x: not x.product_id and x.product_tmpl_id.product_variant_ids

--- a/product_multi_barcode/tests/test_product_multi_barcode.py
+++ b/product_multi_barcode/tests/test_product_multi_barcode.py
@@ -21,6 +21,15 @@ class TestProductMultiBarcode(TransactionCase):
         self.valid_barcode_2 = "9780471117094"
         self.valid_barcode2_2 = "4006381333931"
 
+    def test_create_template(self):
+        tmpl = self.env["product.template"].create(
+            {
+                "name": "Foo",
+                "barcode": self.valid_barcode_1,
+            }
+        )
+        self.assertEqual(tmpl.barcode_ids.product_id, tmpl.product_variant_ids)
+
     def test_set_main_barcode(self):
         self.product_1.barcode = self.valid_barcode_1
         self.assertEqual(len(self.product_1.barcode_ids), 1)


### PR DESCRIPTION
When having a product with a lot of variant
if you try to remove some product.attribute.value
it will remove the related product.product
and everytime a product.product is remove
this will trigger the computed field
On my db removing a product.product take 10s without this change and 3s after

A test have been added to check that this change to not have impact when creating a product_template with a barcode

@kev-Roche
