### PR TITLE
[14.0][FIX] barcodes_generator_product_multi_barcode: fix inheritance

### DIFF
--- a/barcodes_generator_product_multi_barcode/models/barcode_generate_mixin.py
+++ b/barcodes_generator_product_multi_barcode/models/barcode_generate_mixin.py
@@ -1,28 +1,23 @@
 import barcode
 
-from odoo import api, fields, models
+from odoo import models
 
 
-class BarcodeGenerateMixin(models.AbstractModel):
-    _inherit = "barcode.generate.mixin"
+class ProductProduct(models.Model):
+    _inherit = "product.product"
 
     def generate_barcode(self):
+        """override to create a product.barcode instead"""
         for item in self:
             padding = item.barcode_rule_id.padding
             str_base = str(item.barcode_base).rjust(padding, "0")
             custom_code = self._get_custom_barcode(item)
             if custom_code:
                 custom_code = custom_code.replace("." * padding, str_base)
-                self._create_barcode(item, custom_code)
-
-    @api.model
-    def _create_barcode(self, item, custom_code):
-        barcode_class = barcode.get_barcode_class(item.barcode_rule_id.encoding)
-        self.env["product.barcode"].create(
-            {
-                "product_id": self.id,
-                "name": barcode_class(
-                    custom_code if custom_code else fields.Datetime.now().to_string()
-                ),
-            }
-        )
+                barcode_class = barcode.get_barcode_class(item.barcode_rule_id.encoding)
+                self.env["product.barcode"].create(
+                    {
+                        "product_id": item.id,
+                        "name": barcode_class(custom_code),
+                    }
+                )


### PR DESCRIPTION
This commit fixes an issue where the barcode generation was being overwritten not just for products, but for every model that inherited from the `barcode.generate.mixin` (users, locations, packages)

Additionally, it also fixes a SingletonError in case `generate_barcode()` was called with a multi recordset