### PR TITLE
[14.0] stock_barcodes: usability improvements

### DIFF
--- a/stock_barcodes/__manifest__.py
+++ b/stock_barcodes/__manifest__.py
@@ -26,6 +26,7 @@
         # Keep order
         "data/stock_barcodes_action.xml",
         "data/stock_barcodes_option.xml",
+        "data/stock_picking_type.xml",
         "views/stock_barcodes_menu.xml",
     ],
     "installable": True,

--- a/stock_barcodes/data/stock_picking_type.xml
+++ b/stock_barcodes/data/stock_picking_type.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <record id="stock.picking_type_in" model="stock.picking.type">
+        <field
+            name="barcode_option_group_id"
+            ref="stock_barcodes_option_group_picking_in"
+        />
+        <field
+            name="new_picking_barcode_option_group_id"
+            ref="stock_barcodes_option_group_picking_in"
+        />
+    </record>
+
+    <record id="stock.picking_type_out" model="stock.picking.type">
+        <field
+            name="barcode_option_group_id"
+            ref="stock_barcodes_option_group_picking_out"
+        />
+    </record>
+
+    <record id="stock.picking_type_internal" model="stock.picking.type">
+        <field
+            name="barcode_option_group_id"
+            ref="stock_barcodes_option_group_picking_internal"
+        />
+    </record>
+
+</odoo>

--- a/stock_barcodes/models/stock_barcodes_option.py
+++ b/stock_barcodes/models/stock_barcodes_option.py
@@ -34,6 +34,10 @@ class StockBarcodesOptionGroup(models.Model):
     show_pending_moves = fields.Boolean(
         string="Show pending moves", help="Shows a list of movements to process"
     )
+    show_all_moves = fields.Boolean(
+        string="Show all moves",
+        help="Keep showing moves after they're completed",
+    )
     source_pending_moves = fields.Selection(
         [("move_line_ids", "Detailed operations"), ("move_lines", "Operations")],
         default="move_line_ids",

--- a/stock_barcodes/views/stock_barcodes_option_view.xml
+++ b/stock_barcodes/views/stock_barcodes_option_view.xml
@@ -22,6 +22,10 @@
                             <field name="confirmed_moves" />
                             <field name="show_pending_moves" />
                             <field
+                                name="show_all_moves"
+                                attrs="{'invisible': [('show_pending_moves', '=', False), ('barcode_guided_mode', '=', False)]}"
+                            />
+                            <field
                                 name="source_pending_moves"
                                 attrs="{'invisible': [('show_pending_moves', '=', False), ('barcode_guided_mode', '=', False)]}"
                             />

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -63,6 +63,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
     selected_pending_move_id = fields.Many2one(
         comodel_name="wiz.stock.barcodes.read.todo"
     )
+    show_all_moves = fields.Boolean(related="option_group_id.show_all_moves")
     show_detailed_operations = fields.Boolean(
         related="option_group_id.show_detailed_operations"
     )

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -116,11 +116,17 @@
                         </templates>
                     </kanban>
                 </field>
-                <field name="todo_line_display_ids" mode="kanban" force_save="1" />
+                <field
+                    name="todo_line_display_ids"
+                    mode="kanban"
+                    force_save="1"
+                    attrs="{'invisible': [('show_all_moves', '=', True)]}"
+                />
             </xpath>
             <field name="location_id" position="before">
                 <field name="picking_type_code" invisible="1" force_save="1" />
                 <field name="picking_id" invisible="1" force_save="1" />
+                <field name="show_all_moves" invisible="1" />
                 <field name="show_detailed_operations" invisible="1" />
             </field>
             <group name="location" position="attributes">
@@ -152,91 +158,41 @@
             </group>
             <group name="scan_fields" position="after">
                 <group
+                    string="All moves"
+                    attrs="{'invisible': [
+                        '|',
+                            ('show_all_moves', '=', False),
+                            ('todo_line_ids', '=', []),
+                    ]}"
+                >
+                    <field
+                        name="todo_line_ids"
+                        options="{'no_open': True, 'always_reload': True}"
+                        context="{'kanban_view_ref':'stock_barcodes.view_stock_barcodes_todo_kanban_multi'}"
+                        nolabel="1"
+                        force_save="1"
+                        mode="kanban"
+                    />
+                </group>
+                <group
                     string="Pending moves"
-                    attrs="{'invisible': [('pending_move_ids', '=', [])]}"
+                    attrs="{'invisible': [
+                        '|',
+                            ('show_all_moves', '=', True),
+                            ('pending_move_ids', '=', [])
+                    ]}"
                 >
                     <field
                         name="pending_move_ids"
                         options="{'no_open': True, 'always_reload': True}"
+                        context="{
+                            'kanban_view_ref':'stock_barcodes.view_stock_barcodes_todo_kanban_embed',
+                            'tree_view_ref':'stock_barcodes.view_stock_barcodes_todo_tree_embed',
+                        }"
                         nolabel="1"
                         force_save="1"
                         mode="tree,kanban"
-                    >
-                        <tree>
-                            <field name="state" invisible="1" />
-                            <field name="product_id" />
-                            <field name="product_uom_qty" />
-                            <field name="line_ids" invisible="1" />
-                            <field
-                                name="lot_id"
-                                groups="stock.group_production_lot"
-                                optional="hide"
-                            />
-                            <field
-                                name="package_id"
-                                groups="stock.group_tracking_lot"
-                                optional="hide"
-                            />
-                            <field name="qty_done" />
-                            <button
-                                name="fill_from_pending_line"
-                                type="object"
-                                class="btn"
-                                icon="fa-upload"
-                                context="{'wiz_barcode_id': parent.id}"
-                            />
-                        </tree>
-                        <kanban class="o_kanban_mobile">
-                            <field name="state" />
-                            <field name="product_id" />
-                            <field name="product_uom_qty" />
-                            <field name="qty_done" />
-                            <templates>
-                                <t t-name="kanban-box">
-                                    <div t-attf-class="oe_kanban_card">
-                                        <div class="row">
-                                            <div class="col-6">
-                                                <strong>
-                                                    <span>
-                                                        <field name="product_id" />
-                                                    </span>
-                                                </strong>
-                                            </div>
-                                            <div class="col-2">
-                                                <span
-                                                    class="pull-right text-right text-muted"
-                                                >
-                                                    <field name="product_uom_qty" />
-                                                </span>
-                                            </div>
-                                            <div class="col-2">
-                                                <span
-                                                    class="pull-right text-right"
-                                                    t-att-class="qty_done >= product_uom_qty ? 'text-success' : ''"
-                                                >
-                                                    <field name="qty_done" />
-                                                </span>
-                                            </div>
-                                            <div class="col-2 text-right">
-                                                <button
-                                                    name="fill_from_pending_line"
-                                                    type="object"
-                                                    class="btn"
-                                                    context="{'wiz_barcode_id': parent.id}"
-                                                >
-                                                    <i
-                                                        class="fa fa-upload"
-                                                        title="Fill from pencil"
-                                                        style="font-size:1.5em"
-                                                    />
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </t>
-                            </templates>
-                        </kanban>
-                    </field>
+                    />
                 </group>
                 <group
                     string="Detailed operations"

--- a/stock_barcodes/wizard/stock_barcodes_read_todo.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo.py
@@ -192,6 +192,18 @@ class WizStockBarcodesReadTodo(models.TransientModel):
             record = self.wiz_barcode_id.todo_line_ids[self.position_index + 1]
             self.wiz_barcode_id.determine_todo_action(forced_todo_line=record)
 
+    def action_qty_done_minus_one(self):
+        self.ensure_one()
+        self.qty_done = self.line_ids.qty_done = max(self.line_ids.qty_done - 1, 0)
+
+    def action_qty_done_plus_one(self):
+        self.ensure_one()
+        self.qty_done = self.line_ids.qty_done = self.line_ids.qty_done + 1
+
+    def action_qty_done_fill(self):
+        self.ensure_one()
+        self.qty_done = self.line_ids.qty_done = self.product_uom_qty
+
     @api.depends("line_ids.qty_done")
     def _compute_qty_done(self):
         for rec in self:

--- a/stock_barcodes/wizard/stock_barcodes_read_todo_view.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo_view.xml
@@ -157,4 +157,268 @@
             </kanban>
         </field>
     </record>
+
+    <!-- Version of the kanban for multiple records -->
+    <record id="view_stock_barcodes_todo_kanban_multi" model="ir.ui.view">
+        <field name="name">stock.barcodes.todo.kanban</field>
+        <field name="model">wiz.stock.barcodes.read.todo</field>
+        <field name="priority">90</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile" create="0">
+                <field name="picking_code" />
+                <field name="location_id" />
+                <field name="location_name" />
+                <field name="location_dest_id" />
+                <field name="location_dest_name" />
+                <field name="product_id" />
+                <field name="lot_id" />
+                <field name="uom_id" />
+                <field name="package_id" />
+                <field name="result_package_id" />
+                <field name="package_product_qty" />
+                <field name="product_uom_qty" />
+                <field name="qty_done" />
+                <field name="line_ids" invisible="1" />
+                <field name="state" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div
+                            t-attf-class="oe_kanban_content "
+                            style="background-color: #FFF8DC; width: 100%;"
+                        >
+                            <div class="row">
+                                <div class="col-3">
+                                        <div class="row">
+                                            <div class="col">
+                                                <span
+                                                class="fa fa-map-marker"
+                                                title="Location name"
+                                            />
+                                                <strong>
+                                                    <span
+                                                    attrs="{'invisible': [('picking_code', '!=', 'incoming')]}"
+                                                >
+                                                        <field
+                                                        name="location_dest_name"
+                                                    />
+                                                    </span>
+                                                    <span
+                                                    attrs="{'invisible': [('picking_code', '!=', 'internal')]}"
+                                                >
+                                                        <field
+                                                        name="location_name"
+                                                    /> \u21E8 <field
+                                                        name="location_dest_name"
+                                                    />
+                                                    </span>
+                                                    <span
+                                                    attrs="{'invisible': [('picking_code', '!=', 'outgoing')]}"
+                                                >
+                                                        <field name="location_name" />
+                                                    </span>
+                                                </strong>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col">
+                                                <strong>
+                                                    <field name="product_id" />
+                                                </strong>
+                                            </div>
+                                        </div>
+                                        <t
+                                        t-if="record.lot_id or record.package_id or record.result_package_id"
+                                    >
+                                            <table>
+                                                <tr>
+                                                    <td>
+                                                        <span>
+                                                            <span
+                                                            class="fa fa-tags"
+                                                            title="Lot S/N"
+                                                        />
+                                                            <field name="lot_id" />
+                                                        </span>
+                                                    </td>
+                                                    <td class="text-right">
+                                                        <span class="fa fa-dropbox" />
+                                                        <span>
+                                                            <field name="package_id" />
+                                                            <t
+                                                            t-if="record.package_id"
+                                                        >(<span
+                                                                t-esc="record.package_product_qty.value"
+                                                            /> <t
+                                                                t-esc="record.uom_id.value.slice(0,3)"
+                                                            />)</t>
+                                                        </span>
+                                                        <span>
+                                                            <field
+                                                            name="result_package_id"
+                                                        />
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </t>
+                                        <div class="row">
+                                            <div class="col-12">
+                                                <span>
+                                                    <span class="font-weight-bold">
+                                                        <t
+                                                        t-esc="record.qty_done.value"
+                                                    />
+                                                    </span> / <t
+                                                    t-esc="record.product_uom_qty.value"
+                                                /> <t
+                                                    t-esc="record.uom_id.value.slice(0,3)"
+                                                />
+                                                </span>
+                                            </div>
+                                        </div>
+                                </div>
+                                <div class="col-9 font-weight-bold" name="controls">
+                                    <div
+                                        class="row align-items-center justify-content-end text-center h-100"
+                                    >
+                                        <div
+                                            class="col-1 m-2 p-2"
+                                            style="background-color: #5AC4f6;"
+                                        >
+                                            <button
+                                                name="action_qty_done_minus_one"
+                                                type="object"
+                                                class="btn w-100 h-100"
+                                            >
+                                                <span class="fa fa-minus" />
+                                            </button>
+                                        </div>
+                                        <div
+                                            class="col-3 m-2 p-4"
+                                            style="background-color: #5AC4f6;"
+                                        >
+                                            <t t-esc="record.qty_done.value" />
+                                        </div>
+                                        <div
+                                            class="col-1 m-2 p-2"
+                                            style="background-color: #5AC4f6;"
+                                        >
+                                            <button
+                                                name="action_qty_done_plus_one"
+                                                type="object"
+                                                class="btn w-100 h-100"
+                                            >
+                                                <span class="fa fa-plus" />
+                                            </button>
+                                        </div>
+                                        <div
+                                            class="col-3 m-2 p-4"
+                                            style="background-color: #5AC4f6;"
+                                        >
+                                            <button
+                                                name="action_qty_done_fill"
+                                                type="object"
+                                                class="btn w-100 h-100"
+                                            >
+                                                Fill
+                                            </button>
+                                        </div>
+                                        <div class="col-1" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_stock_barcodes_todo_kanban_embed" model="ir.ui.view">
+        <field name="name">stock.barcodes.todo.kanban.embed</field>
+        <field name="model">wiz.stock.barcodes.read.todo</field>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <field name="state" />
+                <field name="product_id" />
+                <field name="product_uom_qty" />
+                <field name="qty_done" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="oe_kanban_card">
+                            <div class="row">
+                                <div class="col-6">
+                                    <strong>
+                                        <span>
+                                            <field name="product_id" />
+                                        </span>
+                                    </strong>
+                                </div>
+                                <div class="col-2">
+                                    <span class="pull-right text-right text-muted">
+                                        <field name="product_uom_qty" />
+                                    </span>
+                                </div>
+                                <div class="col-2">
+                                    <span
+                                        class="pull-right text-right"
+                                        t-att-class="qty_done >= product_uom_qty ? 'text-success' : ''"
+                                    >
+                                        <field name="qty_done" />
+                                    </span>
+                                </div>
+                                <div class="col-2 text-right">
+                                    <button
+                                        name="fill_from_pending_line"
+                                        type="object"
+                                        class="btn"
+                                        context="{'wiz_barcode_id': parent.id}"
+                                    >
+                                        <i
+                                            class="fa fa-upload"
+                                            title="Fill from pencil"
+                                            style="font-size:1.5em"
+                                        />
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_stock_barcodes_todo_tree_embed" model="ir.ui.view">
+        <field name="name">stock.barcodes.todo.tree</field>
+        <field name="model">wiz.stock.barcodes.read.todo</field>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="state" invisible="1" />
+                <field name="product_id" />
+                <field name="product_uom_qty" />
+                <field name="line_ids" invisible="1" />
+                <field
+                    name="lot_id"
+                    groups="stock.group_production_lot"
+                    optional="hide"
+                />
+                <field
+                    name="package_id"
+                    groups="stock.group_tracking_lot"
+                    optional="hide"
+                />
+                <field name="qty_done" />
+                <button
+                    name="fill_from_pending_line"
+                    type="object"
+                    class="btn"
+                    icon="fa-upload"
+                    context="{'wiz_barcode_id': parent.id}"
+                />
+            </tree>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION

- First commit modifies data files to immediately associate barcode options with the related stock.picking.type

- Second commit adds an option "Show All" in barcode options. If checked, there's only a single table in the barcode interface that shows all moves, both pending and done. With the previous configuration, one could show only pending moves, which would disappear as soon as they were done; there is an option to show completed moves in a separate table, too.