### PR TITLE
[15.0][FIX] stock_barcodes: Error when using arrows on Inventory Overview

### DIFF
--- a/stock_barcodes/static/src/js/kanban_renderer.js
+++ b/stock_barcodes/static/src/js/kanban_renderer.js
@@ -32,11 +32,13 @@ odoo.define("stock_barcodes.KanbanRenderer", function (require) {
          * @override
          */
         _onRecordKeyDown: function (ev) {
-            if (this._is_valid_barcode_model) {
-                if (this._controller_base) {
-                    ev.stopPropagation();
-                    this._controller_base._onDocumentKeyDown(ev);
-                }
+            if (
+                this._is_valid_barcode_model &&
+                this._controller_base &&
+                this._controller_base._onDocumentKeyDown
+            ) {
+                ev.stopPropagation();
+                this._controller_base._onDocumentKeyDown(ev);
             } else {
                 this._super.apply(this, arguments);
             }


### PR DESCRIPTION
To reproduce the error use arrows of the keyboard on the Inventory Overview. An error will be thrown because the function _onDocumentKeyDown is undefined.

By doing this change, when the function is undefined it will work like normally it does.

cc @Tecnativa TT49029

ping @carlosdauden @sergio-teruel 