### PR TITLE
[IMP] sale_input_barcode: scan directly on sale.order

### DIFF
--- a/sale_input_barcode/README.rst
+++ b/sale_input_barcode/README.rst
@@ -47,8 +47,16 @@ Usage
 #. Press the button in the header with the QR Code icon
 #. Use a barcode scanner to scan a barcode.
 
+Alternatively,
+#. Navigate to a Sales Order.
+#. Activate "Edit Mode"
+#. Use a barcode scanner to scan a barcode.
+
 If a product is found using the barcode,
 a new line with that product will be added to the Sales Order.
+
+If a product is already inside the sale order lines,
+the quantity will be updated.
 
 Bug Tracker
 ===========

--- a/sale_input_barcode/models/product_barcode_line_mixin.py
+++ b/sale_input_barcode/models/product_barcode_line_mixin.py
@@ -26,9 +26,16 @@ class ProductLineMixin(models.AbstractModel):
         Builds a dictionary to use in the `create` function
         Hook for customizations
         """
-        vals = {"product_id": product.id}
+        vals = {
+            "product_id": product.id,
+            "product_uom_qty": 1,
+        }
         if "order_id" in self._fields:
-            vals["order_id"] = self.env.context.get("order_id")
+            order_id = self.env.context.get("order_id")
+            if isinstance(order_id, models.NewId):
+                vals["order_id"] = order_id.origin
+            else:
+                vals["order_id"] = order_id
         return vals
 
     def _process_barcode_on_product_line(self, raw_barcode):
@@ -48,5 +55,4 @@ class ProductLineMixin(models.AbstractModel):
                 _("No product found matching this barcode %s" % barcode_str)
             )
 
-        vals = self._populate_vals(product, barcode_dict)
-        self.create(vals)
+        return self._populate_vals(product, barcode_dict)

--- a/sale_input_barcode/models/sale_order.py
+++ b/sale_input_barcode/models/sale_order.py
@@ -9,11 +9,34 @@ class SaleOrderLine(models.Model):
 
 
 class SaleOrder(models.Model):
-    _inherit = "sale.order"
+    _name = "sale.order"
+    _inherit = ["sale.order", "barcodes.barcode_events_mixin"]
+
+    def on_barcode_scanned(self, barcode):
+        self.process_barcode(barcode)
 
     def action_sale_line_barcode(self, barcode):
         """Create a sale line according barcode information"""
         self.ensure_one()
-        self.env["sale.order.line"].with_context(
-            order_id=self.id, company_id=self.company_id.id
-        )._process_barcode_on_product_line(barcode)
+        self.process_barcode(barcode)
+
+    def process_barcode(self, barcode):
+        barcode = barcode.rstrip()
+        line_vals = (
+            self.env["sale.order.line"]
+            .with_context(order_id=self.id, company_id=self.company_id.id)
+            ._process_barcode_on_product_line(barcode)
+        )
+
+        product_order_line = self.order_line.filtered(
+            lambda x: x.product_id.id == line_vals.get("product_id")
+        )[:1]
+        if product_order_line:
+            product_order_line.product_uom_qty += 1
+        else:
+            product_order_line = self.env["sale.order.line"].new(line_vals)
+            product_order_line.product_id_change()
+            sale_line_vals = product_order_line._convert_to_write(
+                product_order_line._cache
+            )
+            self.write({"order_line": [(0, 0, sale_line_vals)]})

--- a/sale_input_barcode/readme/CONTIBUTORS.rst
+++ b/sale_input_barcode/readme/CONTIBUTORS.rst
@@ -5,6 +5,8 @@
 * PyTech SRL <info@pytech.it>:
 
     - Alessandro Uffreduzzi <alessandro.uffreduzzi@pytech.it>
+    - Alessio Renda
+
 
 * Ooops404 <info@ooops404.com>:
 

--- a/sale_input_barcode/readme/USAGE.rst
+++ b/sale_input_barcode/readme/USAGE.rst
@@ -2,5 +2,13 @@
 #. Press the button in the header with the QR Code icon
 #. Use a barcode scanner to scan a barcode.
 
+Alternatively,
+#. Navigate to a Sales Order.
+#. Activate "Edit Mode"
+#. Use a barcode scanner to scan a barcode.
+
 If a product is found using the barcode,
 a new line with that product will be added to the Sales Order.
+
+If a product is already inside the sale order lines,
+the quantity will be updated.

--- a/sale_input_barcode/static/description/index.html
+++ b/sale_input_barcode/static/description/index.html
@@ -394,8 +394,14 @@ ul.auto-toc {
 <li>Press the button in the header with the QR Code icon</li>
 <li>Use a barcode scanner to scan a barcode.</li>
 </ol>
+<p>Alternatively,
+#. Navigate to a Sales Order.
+#. Activate “Edit Mode”
+#. Use a barcode scanner to scan a barcode.</p>
 <p>If a product is found using the barcode,
 a new line with that product will be added to the Sales Order.</p>
+<p>If a product is already inside the sale order lines,
+the quantity will be updated.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>

--- a/sale_input_barcode/views/sale.xml
+++ b/sale_input_barcode/views/sale.xml
@@ -24,6 +24,9 @@
                     context="{'default_model': 'sale.order', 'default_method': 'action_sale_line_barcode', 'default_res_id': active_id}"
                 />
             </xpath>
+            <field name="name" position="after">
+                <field name="_barcode_scanned" widget="barcode_handler" />
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
- Add the possibility to directly scan barcodes on the `sale.order` form
- If you scan the same product twice, it will adjust the product quantity instead of creating a new line