### PR TITLE
[IMP] barcodes_generator_abstract: set 'python-barcode' as external_dependencies

### DIFF
--- a/barcodes_generator_abstract/__manifest__.py
+++ b/barcodes_generator_abstract/__manifest__.py
@@ -21,5 +21,5 @@
         "views/menu.xml",
     ],
     "demo": ["demo/res_users.xml"],
-    "external_dependencies": {"python": ["barcode"]},
+    "external_dependencies": {"python": ["python-barcode"]},
 }

--- a/setup/barcodes_generator_abstract/setup.py
+++ b/setup/barcodes_generator_abstract/setup.py
@@ -2,12 +2,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon={
-        "external_dependencies_override": {
-            "python": {
-                "barcode": "python-barcode"
-            }
-        }
-    },
+    odoo_addon=True,
 )
-


### PR DESCRIPTION
Since using the PyPI package has been the recommended way since v12.0 
(see https://github.com/odoo/odoo/pull/25549), this commit sets 'python-barcode' as an external dependency and removes the 'odoo_addon' key from setup.py