### PR TITLE
[16.0][IMP] barcodes_generator_abstract: Avoid double iteration on base generation

### DIFF
--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -67,7 +67,7 @@ class BarcodeGenerateMixin(models.AbstractModel):
                         " 'Generate Type' set to 'Base managed by Sequence'"
                     )
                 )
-            else:
+            elif not item.barcode_base:
                 item.barcode_base = item.barcode_rule_id.sequence_id.next_by_id()
 
     def generate_barcode(self):

--- a/barcodes_generator_abstract/tests/test_barcodes_generator_abstract.py
+++ b/barcodes_generator_abstract/tests/test_barcodes_generator_abstract.py
@@ -82,6 +82,8 @@ class TestBarcodesGeneratorAbstract(TransactionCase, FakeModelLoader):
         self.user_fake.generate_barcode()
         self.assertEqual(self.user_fake.barcode, "2000001000007")
 
+        self.user_fake.barcode_base = False
+
         self.user_fake.generate_base()
         self.assertEqual(self.user_fake.barcode_base, 2)
         self.user_fake.generate_barcode()


### PR DESCRIPTION
### Module

barcodes_generator_abstract

### Describe the bug

The base is changed when it is generated by having the ‘Automatic generation’ marked in the barcode nomenclature.

### To Reproduce

1. Configure the Automatic generation in the barcode nomenclature
2. Create / Edit a product barcode rule
3. Press on "Generate base"

(image from runboat OCA)

![image](https://github.com/OCA/stock-logistics-barcode/assets/134701949/22270cf2-d58d-4670-8631-b99958dc9efb)

![image](https://github.com/OCA/stock-logistics-barcode/assets/134701949/ab20e41e-84b6-44a2-9f44-501b69be5828)

![image](https://github.com/OCA/stock-logistics-barcode/assets/134701949/74182a1c-005f-4cf3-846d-a3cd6c293f28)

![image](https://github.com/OCA/stock-logistics-barcode/assets/134701949/7815cf10-8d21-41e9-b303-2fe1c1e271ca)

**Affected versions:**

16.0

**Additional context**

The problem is that when going through this function inside the [barcodes_generator_product](https://github.com/OCA/stock-logistics-barcode/tree/16.0/barcodes_generator_product) it goes back through the generate_base() and a recalculation of the base incorrectly, as it already has one before. With this change it would be solved