### PR TITLE
[15.0][FIX] stock_barcodes_gs1: Key error in result when fails gs1 barcode read

### DIFF
--- a/stock_barcodes_gs1/models/barcode_nomenclature.py
+++ b/stock_barcodes_gs1/models/barcode_nomenclature.py
@@ -7,5 +7,6 @@ class BarcodeNomenclature(models.Model):
     def parse_gs1_rule_pattern(self, match, rule):
         # Allow use weight ai as units directly for products with unit category uom
         result = super().parse_gs1_rule_pattern(match, rule)
-        result["use_weight_as_unit"] = True if rule.use_weight_as_unit else False
+        if result:
+            result["use_weight_as_unit"] = rule.use_weight_as_unit
         return result


### PR DESCRIPTION
cc @Tecnativa TT50989

Commit added to 16.0 here https://github.com/OCA/stock-logistics-barcode/pull/634/commits/287662447675d4d529ba64cf46b5cb5dbee5ad42

ping @carlosdauden @chienandalu 