### PR TITLE
[FIX] barcode_generator_abstract: do not compute a new barcode_base, if the item has already a barcode_base defined.

### DIFF
--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -37,10 +37,8 @@ class BarcodeGenerateMixin(models.AbstractModel):
         for rec in records:
             rule = rec.barcode_rule_id
             if rule and rule.generate_automate and rule.generate_type == "sequence":
-                if not rec.barcode_base:
-                    rec.generate_base()
-                if not rec.barcode:
-                    rec.generate_barcode()
+                rec.generate_base()
+                rec.generate_barcode()
         return records
 
     def write(self, vals):
@@ -51,15 +49,17 @@ class BarcodeGenerateMixin(models.AbstractModel):
             rule = self.env["barcode.rule"].browse(vals["barcode_rule_id"])
             if rule.generate_automate and rule.generate_type == "sequence":
                 for rec in self:
-                    if not rec.barcode_base:
-                        rec.generate_base()
-                    if not rec.barcode:
-                        rec.generate_barcode()
+                    rec.generate_base()
+                    rec.generate_barcode()
         return res
 
     # View Section
     def generate_base(self):
-        for item in self:
+        """Generate a base barcode, based on sequence, if the item
+        has no barcode defined.
+        Raise an exception if the generate_type of the barcode rule
+        is not set to 'sequence'."""
+        for item in self.filtered(lambda x: not x.barcode_base):
             if item.generate_type != "sequence":
                 raise exceptions.UserError(
                     _(

--- a/barcodes_generator_abstract/tests/test_barcodes_generator_abstract.py
+++ b/barcodes_generator_abstract/tests/test_barcodes_generator_abstract.py
@@ -82,6 +82,7 @@ class TestBarcodesGeneratorAbstract(TransactionCase, FakeModelLoader):
         self.user_fake.generate_barcode()
         self.assertEqual(self.user_fake.barcode, "2000001000007")
 
+        self.user_fake.barcode_base = False
         self.user_fake.generate_base()
         self.assertEqual(self.user_fake.barcode_base, 2)
         self.user_fake.generate_barcode()


### PR DESCRIPTION
alternative to #619 with better coverage.

- add a comment to explicit how generate_base() works.
- adapt test.