### PR TITLE
[16.0][FIX] stock_barcodes: play error sound when requested

### DIFF
--- a/stock_barcodes/static/src/views/views.esm.js
+++ b/stock_barcodes/static/src/views/views.esm.js
@@ -113,7 +113,11 @@ function setupView() {
                     (this.model.root.resId == payload.res_id)
                 ) {
                     if (type === "stock_barcodes_sound") {
-                        this.$sound_ok[0].play();
+                        if (payload.sound === "ko") {
+                            this.$sound_ko[0].play();
+                        } else {
+                            this.$sound_ok[0].play();
+                        }
                     }
                     if (type === "stock_barcodes_focus") {
                         requestIdleCallback(() => {


### PR DESCRIPTION
Without this fix, stock_barcodes v16 would always play the bell sound even in case of error.