### PR TITLE
[16.0][IMP] stock_barcodes: use trash icons instead of recycle icons in inventory

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_inventory_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_inventory_views.xml
@@ -84,7 +84,7 @@
                                 name="action_barcode_inventory_quant_unlink"
                                 type="object"
                                 class="btn"
-                                icon="fa-recycle"
+                                icon="fa-trash"
                                 title="Remove quant"
                                 context="{'wiz_barcode_id': parent.id}"
                             />
@@ -127,7 +127,7 @@
                                                 <button
                                                     name="action_barcode_inventory_quant_unlink"
                                                     type="object"
-                                                    icon="fa-recycle"
+                                                    icon="fa-trash"
                                                     title="Reset inventory quantity"
                                                     class="btn mt0"
                                                     context="{'wiz_barcode_id': parent.id}"


### PR DESCRIPTION
BEFORE

![stock_barcodes_before](https://github.com/user-attachments/assets/8bff706b-904a-40de-9b2a-734586a9e777)

AFTER

![stock_barcodes-after](https://github.com/user-attachments/assets/41f52ce1-73d4-46ec-8262-78ecc5daf929)
