### PR TITLE
[14.0] stock_barcodes: enable filter on products for inventory

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -176,6 +176,9 @@ class WizStockBarcodesRead(models.AbstractModel):
             return True
         return False
 
+    def _hook_process_barcode_product(self, product):
+        return True
+
     def process_barcode_product_id(self):
         domain = self._barcode_domain(self.barcode)
         product = self.env["product.product"].search(domain)
@@ -187,6 +190,9 @@ class WizStockBarcodesRead(models.AbstractModel):
                 self._set_messagge_info(
                     "not_found", _("The product type is not allowed")
                 )
+                return False
+            res_hook = self._hook_process_barcode_product(product)
+            if res_hook is False:
                 return False
             self.action_product_scaned_post(product)
             # self.action_done()

--- a/stock_barcodes/wizard/stock_barcodes_read_inventory.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_inventory.py
@@ -9,6 +9,7 @@ class WizStockBarcodesReadInventory(models.TransientModel):
     _name = "wiz.stock.barcodes.read.inventory"
     _inherit = "wiz.stock.barcodes.read"
     _description = "Wizard to read barcode on inventory"
+    _allowed_product_types = ["product"]
 
     inventory_id = fields.Many2one(comodel_name="stock.inventory", readonly=True)
     inventory_product_qty = fields.Float(
@@ -165,3 +166,18 @@ class WizStockBarcodesReadInventory(models.TransientModel):
     def _onchange_lot_id(self):
         if self.lot_id and not self.env.context.get("keep_auto_lot"):
             self.auto_lot = False
+
+    def _hook_process_barcode_product(self, product):
+        if (
+            self.inventory_id.product_ids
+            and product.id not in self.inventory_id.product_ids.ids
+        ):
+            self._set_messagge_info(
+                "not_found",
+                _(
+                    "This inventory is filtered on products and product '%s' is not part of it."
+                )
+                % product.display_name,
+            )
+            return False
+        return super()._hook_process_barcode_product(product)


### PR DESCRIPTION
Before this PR:

When working on an inventory filtered on products, there is no error message when a users scans a product which is not part of the product filter and a new inventory line is created (in the backoffice, it is not possible to create a new inventory line for a product which is not part of the product filter due to a domain, cf https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_inventory.py#L342)

With this PR: 
When you scan a product which is not part of the product filter of the inventory, you get an error sound and this message:

![error_bad_product](https://github.com/user-attachments/assets/ac730ee5-bd64-464f-90cc-9cd1fb4c9582)
