### PR TITLE
[IMP] barcodes_generator_abstract: use available 'optional' option on rule tree view.

### DIFF
--- a/barcodes_generator_abstract/views/view_barcode_nomenclature.xml
+++ b/barcodes_generator_abstract/views/view_barcode_nomenclature.xml
@@ -13,10 +13,18 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <field
                     name="generate_type"
                     attrs="{'invisible': [('generate_type', '=', 'no')]}"
+                    optional="show"
+                />
+                <field name="generate_model" optional="hide" />
+                <field
+                    name="generate_automate"
+                    attrs="{'invisible': [('generate_type', '!=', 'sequence')]}"
+                    optional="hide"
                 />
                 <field
-                    name="generate_model"
-                    attrs="{'invisible': [('generate_type', '=', 'no')]}"
+                    name="sequence_id"
+                    attrs="{'invisible': [('generate_type', '!=', 'sequence')]}"
+                    optional="hide"
                 />
             </field>
         </field>


### PR DESCRIPTION
- Add extra generate_automate and sequence_id fields, (hidden by default)
