### PR TITLE
[14.0][FIX]: stock_barcodes: wizard update qty_done

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_todo.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo.py
@@ -41,7 +41,7 @@ class WizStockBarcodesReadTodo(models.TransientModel):
     qty_done = fields.Float(
         "Done",
         digits="Product Unit of Measure",
-        readonly=False,
+        readonly=True,
         compute="_compute_qty_done",
         store=True,
     )


### PR DESCRIPTION
Readonly on the qty_done field of the wizard to update the field value following the scan of an article reference