### PR TITLE
[16.0][IMP] stock_barcodes: add explicit error message when barcode option group is not configured on picking type

### DIFF
--- a/stock_barcodes/models/stock_picking.py
+++ b/stock_barcodes/models/stock_picking.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Sergio Teruel <sergio.teruel@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import models
+from odoo import _, models
+from odoo.exceptions import UserError
 
 
 class StockPicking(models.Model):
@@ -33,6 +34,14 @@ class StockPicking(models.Model):
             or self.picking_type_id.barcode_option_group_id
             or self.env.ref("stock_barcodes.stock_barcodes_option_group_operation")
         )
+        if not option_group:
+            raise UserError(
+                _(
+                    "Barcode Option Group is not configured on "
+                    "Operation Type '%(pick_type)s'.",
+                    pick_type=self.picking_type_id.display_name,
+                )
+            )
         wiz = self.env["wiz.stock.barcodes.read.picking"].create(
             self._prepare_barcode_wiz_vals(option_group)
         )


### PR DESCRIPTION
When you forgot to configuration barcode option group on the picking type, you will get a crash on the first scan:

```
2025-06-23 12:21:14,999 2768114 INFO test1 werkzeug: 90.85.230.27 - - [23/Jun/2025 12:21:14] "POST /web/dataset/call_kw/stock.move.line/read HTTP/1.0" 200 - 12 0.020 0.014
2025-06-23 12:21:15,107 2768114 ERROR test1 odoo.http: Exception during request handling.
Traceback (most recent call last):
  File "/home/odoo/erp16/odoo/odoo/http.py", line 2068, in __call__
    response = request._serve_db()
               ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/http.py", line 1656, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/service/model.py", line 152, in retrying
    result = func()
             ^^^^^^
  File "/home/odoo/erp16/odoo/odoo/http.py", line 1684, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/http.py", line 1888, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/http.py", line 732, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/addons/web/controllers/dataset.py", line 47, in call_button
    action = self._call_kw(model, method, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(Model, method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs) 
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/stock-logistics-barcode/stock_barcodes/wizard/stock_barcodes_read.py", line 475, in dummy_on_barcode_scanned
    self.process_barcode(self.barcode)
  File "/home/odoo/erp16/symlink/stock_barcodes_gs1/wizard/stock_barcodes_read.py", line 193, in process_barcode
    return self.action_confirm()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/stock-logistics-barcode/stock_barcodes/wizard/stock_barcodes_read.py", line 718, in action_confirm
    res = self.action_done()
          ^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/stock-logistics-barcode/stock_barcodes/wizard/stock_barcodes_read_picking.py", line 305, in action_done
    res = super().action_done()
          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/stock-logistics-barcode/stock_barcodes/wizard/stock_barcodes_read.py", line 558, in action_done--
    if not self.check_done_conditions():
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/stock-logistics-barcode/stock_barcodes/wizard/stock_barcodes_read_picking.py", line 724, in check_done_conditions
    and float_compare(
        ^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/tools/float_utils.py", line 155, in float_compare
    rounding_factor = _float_check_precision(precision_digits=precision_digits,
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/erp16/odoo/odoo/tools/float_utils.py", line 29, in _float_check_precision
    assert precision_rounding is None or precision_rounding > 0,\
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: precision_rounding must be positive, got 0.0
```

Moreover, the backtrace of this crash make it very difficult to understand that the cause of the crash is as simple as missing barcode option group on the picking type.

With this PR, the user will have an explicit error message  when he clicks on the barcode button on the picking.
