### PR TITLE
[16.0][FIX] stock_picking_product_barcode_report: Fix parameter name in barcode generation (type → barcode_type)

### DIFF
--- a/stock_picking_product_barcode_report/controllers/main.py
+++ b/stock_picking_product_barcode_report/controllers/main.py
@@ -13,14 +13,14 @@ class ReportController(ReportController):
     @http.route()
     def report_barcode(
         self,
-        type,  # pylint: disable=redefined-builtin
+        barcode_type,
         value,
         width=600,
         height=100,
         humanreadable=0,
         quiet=1,
     ):
-        if type == "gs1_128":
+        if barcode_type == "gs1_128":
             Gs1_128 = barcode.get_barcode_class("gs1_128")
             writer = SVGWitoutTextWriter(module_max_height=height)
             gs1_128 = Gs1_128(str(value), writer=writer)
@@ -31,7 +31,7 @@ class ReportController(ReportController):
                 image, headers=[("Content-Type", "image/svg+xml")]
             )
         return super().report_barcode(
-            type,
+            barcode_type,
             value,
             width=width,
             height=height,

--- a/stock_picking_product_barcode_report/report/report_label_barcode_template.xml
+++ b/stock_picking_product_barcode_report/report/report_label_barcode_template.xml
@@ -6,7 +6,7 @@
                 <t t-foreach="doc.label_qty" t-as="i">
                     <div class="text-center">
                         <t t-if="doc.wizard_id.barcode_format == 'gs1_128'">
-                            <t t-set="type" t-value="'gs1_128'" />
+                            <t t-set="barcode_type" t-value="'gs1_128'" />
                             <t
                                 t-set="barcode"
                                 t-value="doc.product_id.barcode.zfill(14)"
@@ -18,7 +18,7 @@
                                     t-value="'02' + barcode + '10' + lot.name"
                                 />
                                 <img
-                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % (type, value, 600, 60)"
+                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % (barcode_type, value, 600, 60)"
                                     style="width:100%;height:70px;margin: 0px 0px -25px 0px"
                                     alt="Barcode"
                                 />
@@ -30,7 +30,7 @@
                             <t t-else="">
                                 <t t-set="value" t-value="'02' + barcode" />
                                 <img
-                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % (type, value, 600, 60)"
+                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % (barcode_type, value, 600, 60)"
                                     style="width:100%;height:70px;margin: 0px 0px -25px 0px"
                                     alt="Barcode"
                                 />


### PR DESCRIPTION
Before the fix, barcode images were not rendered correctly in reports when using the gs1_128 format. This was caused by a mismatch between the parameter name used in the report template (type) and the one expected by the controller (barcode_type):
<img width="430" height="290" alt="image" src="https://github.com/user-attachments/assets/126e192c-bb8d-4f03-b0c2-16d9826d3c7a" />

This commit updates the QWeb template to use barcode_type consistently and modifies the controller to accept the correct parameter.

Cherry-picked from commit c8aff03b49aaa670724c6b266e106fc5176b505e (17.0).

@ValentinVinagre @HaraldPanten @Jaimermaccione 