### PR TITLE
[15.0][FIX] stock_picking_product_barcode_report: Error printing from quants…

### DIFF
--- a/stock_picking_product_barcode_report/report/report_label_barcode.xml
+++ b/stock_picking_product_barcode_report/report/report_label_barcode.xml
@@ -16,16 +16,17 @@
         />
         <field name="is_barcode_label">True</field>
     </record>
+    <!--  Use distinct report_file because model is taken from first definition  -->
     <record id="action_label_barcode_report_quant_package" model="ir.actions.report">
         <field name="name">Label Quant Package</field>
         <field name="model">stock.picking.line.print</field>
         <field name="report_type">qweb-pdf</field>
         <field
             name="report_file"
-        >stock_picking_product_barcode_report.label_barcode_report_quant_package</field>
+        >stock_picking_product_barcode_report.label_barcode_report_quant_package_wiz</field>
         <field
             name="report_name"
-        >stock_picking_product_barcode_report.label_barcode_report_quant_package</field>
+        >stock_picking_product_barcode_report.label_barcode_report_quant_package_wiz</field>
         <field
             name="paperformat_id"
             ref="stock_picking_product_barcode_report.paperformat_label_quant_package"

--- a/stock_picking_product_barcode_report/report/report_label_barcode_quant_package_template.xml
+++ b/stock_picking_product_barcode_report/report/report_label_barcode_quant_package_template.xml
@@ -93,6 +93,17 @@
             </t>
         </t>
     </template>
+    <!--  Duplicated by quant or wizard because model is taken from first definition  -->
+    <template id="label_barcode_report_quant_package_wiz">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t
+                    t-call="stock_picking_product_barcode_report.report_label_barcode_quant_package"
+                    t-lang="doc.env.user.lang"
+                />
+            </t>
+        </t>
+    </template>
     <!-- Print labels from package quants -->
     <template id="label_barcode_report_package_content">
         <t t-call="web.html_container">


### PR DESCRIPTION
… because doc model is interpreted as stock.picking.line.print
Seems that first ir.action.report definition set the model for all report_file calls

@Tecnativa

Ping @carlos-lopez-tecnativa @CarlosRoca13 