### PR TITLE
[16][FIX] stock_barcodes: Display lot name and package instead of the id

### DIFF
--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -276,17 +276,13 @@
                                                     class="d-flex justify-content-start align-items-center indent h4 pt-3"
                                                 >
                                                     <t t-if="record.lot_id.raw_value">
-                                                        Lot:
-                                                        <span
-                                                            t-esc="record.lot_id.raw_value"
-                                                        />
+                                                        Lot: <field name="lot_id" />
                                                     </t>
                                                     <t
                                                         t-if="record.result_package_id.raw_value"
                                                     >
-                                                        Package:
-                                                        <span
-                                                            t-esc="record.result_package_id.raw_value"
+                                                        Package: <field
+                                                            name="result_package_id"
                                                         />
                                                     </t>
                                                 </div>
@@ -294,11 +290,7 @@
                                             <div
                                                 class="col-4 col-md-4 d-flex justify-content-end align-items-center"
                                             >
-                                                <span
-                                                    class="h3"
-                                                    t-esc="record.qty_done.raw_value"
-                                                />
-
+                                                <field class="h3" name="qty_done" />
                                                 <button
                                                     name="action_barcode_detailed_operation_unlink"
                                                     type="object"

--- a/stock_barcodes/wizard/stock_barcodes_read_todo.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo.py
@@ -174,6 +174,7 @@ class WizStockBarcodesReadTodo(models.TransientModel):
         for field in self.fields_to_fill_from_pending_line():
             self.wiz_barcode_id[field] = self[field]
         # Force fill product_qty if filled_default is set
+        self.wiz_barcode_id.product_qty = 0.0
         if self.wiz_barcode_id.option_group_id.get_option_value(
             "product_qty", "filled_default"
         ):
@@ -185,12 +186,11 @@ class WizStockBarcodesReadTodo(models.TransientModel):
         self.wiz_barcode_id._set_focus_on_qty_input()
 
     def operation_quantities(self):
+        self.fill_from_pending_line()
         self.wiz_barcode_id.manual_entry = True
         self.wiz_barcode_id.product_qty = self.product_qty_reserved
-        self.wiz_barcode_id.product_id = self.product_id.id
         if self.wiz_barcode_id.picking_id.picking_type_id.code != "incoming":
             self.wiz_barcode_id.qty_available = self.product_qty_reserved
-            self.wiz_barcode_id.product_id = self.product_id.id
             self.wiz_barcode_id.location_id = self.location_id.id
         self.wiz_barcode_id.with_context(manual_picking=True).action_confirm()
 
@@ -206,14 +206,8 @@ class WizStockBarcodesReadTodo(models.TransientModel):
     def action_barcode_inventory_quant_edit(self):
         wiz_barcode_id = self.env.context.get("wiz_barcode_id", False)
         wiz_barcode = self.env["wiz.stock.barcodes.read.picking"].browse(wiz_barcode_id)
-        for quant in self:
-            # Try to assign fields with the same name between quant and the scan wizard
-            for fname in self._get_fields_to_edit():
-                if hasattr(wiz_barcode, fname):
-                    wiz_barcode[fname] = quant[fname]
-            wiz_barcode.product_qty = quant.qty_done
-
         wiz_barcode.manual_entry = True
+        self.fill_from_pending_line()
         self.env["bus.bus"]._sendone(
             "stock_barcodes_scan",
             "stock_barcodes_edit_manual",


### PR DESCRIPTION
cc @Tecnativa

The purpose of this PR is to correct all the errors found in the stock_barcodes module when making the design change.
I am testing on a real customer with serious problems... 

ping @carlosdauden @edescalona @Christian-RB 