### PR TITLE
[16.0][IMP] stock_barcodes: Remove 'candidate pickings' feature

### DIFF
--- a/stock_barcodes/security/ir.model.access.csv
+++ b/stock_barcodes/security/ir.model.access.csv
@@ -1,6 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_wiz_stock_barcodes_read_picking,access_wiz_stock_barcodes_read_picking,model_wiz_stock_barcodes_read_picking,base.group_user,1,1,1,1
-access_wiz_candidate_picking,access_wiz_candidate_picking,model_wiz_candidate_picking,base.group_user,1,1,1,1
 access_wiz_stock_barcodes_new_lot,access_wiz_stock_barcodes_new_lot,model_wiz_stock_barcodes_new_lot,base.group_user,1,1,1,1
 access_stock_barcodes_action_manager,access_stock_barcodes_action_manager,model_stock_barcodes_action,base.group_system,1,1,1,1
 access_stock_barcodes_action,access_stock_barcodes_action,model_stock_barcodes_action,base.group_user,1,0,0,0

--- a/stock_barcodes/static/src/scss/stock.scss
+++ b/stock_barcodes/static/src/scss/stock.scss
@@ -76,24 +76,6 @@
         }
     }
 
-    div[name="candidate_picking_ids"] {
-        div.oe_kanban_color_alert {
-            padding: 0 !important;
-            margin: 0 !important;
-        }
-
-        div.o_kanban_ungrouped.o_kanban_renderer {
-            margin: 0 !important;
-            padding: 0 !important;
-        }
-
-        @include media-breakpoint-down(sm) {
-            div.o_kanban_renderer {
-                margin: 2% 1% 2% 1% !important;
-            }
-        }
-    }
-
     div.scan_fields {
         width: 100% !important;
         margin: 0 !important;

--- a/stock_barcodes/tests/common.py
+++ b/stock_barcodes/tests/common.py
@@ -22,7 +22,6 @@ class TestCommonStockBarcodes(TransactionCase):
         cls.ProductPackaging = cls.env["product.packaging"]
         cls.WizScanReadPicking = cls.env["wiz.stock.barcodes.read.picking"]
         cls.WizScanReadInventory = cls.env["wiz.stock.barcodes.read.inventory"]
-        cls.WizCandidatePicking = cls.env["wiz.candidate.picking"]
         cls.StockProductionLot = cls.env["stock.lot"]
         cls.StockPicking = cls.env["stock.picking"]
         cls.StockQuant = cls.env["stock.quant"]
@@ -109,11 +108,6 @@ class TestCommonStockBarcodes(TransactionCase):
         cls.wiz_scan_read_inventory = cls.WizScanReadInventory.create(
             {"option_group_id": cls.option_group.id, "step": 1}
         )
-
-        cls.wiz_scan_candidate_picking = cls.WizCandidatePicking.create(
-            {"wiz_barcode_id": cls.wiz_scan.id}
-        )
-
         # Barcode actions
         cls.barcode_action_valid = cls.StockBarcodeAction.create(
             {

--- a/stock_barcodes/tests/test_stock_barcodes_picking.py
+++ b/stock_barcodes/tests/test_stock_barcodes_picking.py
@@ -196,55 +196,6 @@ class TestStockBarcodesPicking(TestCommonStockBarcodes):
         wiz_scan_picking.action_confirm()
         self.assertEqual(sml.qty_done, 12.0)
 
-    def test_barcode_from_operation(self):
-        picking_out_3 = self.picking_out_01.copy()
-        self.picking_out_01.action_assign()
-        self.picking_out_02.action_assign()
-        self.picking_type_out.default_location_dest_id = self.customer_location
-
-        action = self.picking_type_out.action_barcode_scan()
-        self.wiz_scan_picking = self.ScanReadPicking.browse(action["res_id"])
-        self.wiz_scan_picking.manual_entry = True
-        self.wiz_scan_picking.product_id = self.product_tracking
-        self.wiz_scan_picking.lot_id = self.lot_1
-        self.wiz_scan_picking.product_qty = 2
-
-        self.wiz_scan_picking.with_context(
-            force_create_move=True, no_increase_qty_done=True
-        ).action_confirm()
-        self.assertEqual(len(self.wiz_scan_picking.candidate_picking_ids[0:2]), 2)
-        # Lock first picking
-        candidate = self.wiz_scan_picking.candidate_picking_ids.filtered(
-            lambda c: c.picking_id == self.picking_out_01
-        )
-        candidate_wiz = candidate.with_context(
-            wiz_barcode_id=self.wiz_scan_picking.id, picking_id=self.picking_out_01.id
-        )
-        candidate_wiz.with_context(force_create_move=True).action_lock_picking()
-        self.assertEqual(self.picking_out_01.move_ids.quantity_done, 2)
-        self.wiz_scan_picking.product_qty = 2
-        self.wiz_scan_picking.with_context(
-            force_create_move=True, no_increase_qty_done=True
-        ).action_confirm()
-        self.assertEqual(self.picking_out_01.move_ids.quantity_done, 2)
-
-        # Picking out 3 is in confirmed state, so until confirmed moves has
-        # not been activated candidate pickings is 2
-        picking_out_3.action_confirm()
-        candidate_wiz.action_unlock_picking()
-        self.wiz_scan_picking.product_qty = 2
-        self.wiz_scan_picking.with_context(
-            force_create_move=True, no_increase_qty_done=True
-        ).action_confirm()
-        self.assertEqual(len(self.wiz_scan_picking.candidate_picking_ids[0:2]), 2)
-        candidate_wiz.action_unlock_picking()
-        self.wiz_scan_picking.product_qty = 2
-        self.wiz_scan_picking.option_group_id.confirmed_moves = True
-        self.wiz_scan_picking.with_context(
-            force_create_move=True, no_increase_qty_done=True
-        ).action_confirm()
-        self.assertEqual(len(self.wiz_scan_picking.candidate_picking_ids[0:3]), 3)
-
     def test_picking_wizard_scan_product_auto_lot(self):
         # Prepare more data
         lot_2 = self.StockProductionLot.create(
@@ -527,13 +478,4 @@ class TestStockBarcodesPicking(TestCommonStockBarcodes):
                 ).get_action_picking_tree_ready()
             ),
             dict,
-        )
-        self.assertIsNone(self.wiz_scan_candidate_picking._compute_picking_quantity())
-        self.assertIsNone(self.wiz_scan_candidate_picking._compute_is_pending())
-        self.assertEqual(
-            self.wiz_scan_candidate_picking._get_picking_to_validate()._name,
-            self.picking_in_01._name,
-        )
-        self.assertEqual(
-            type(self.wiz_scan_candidate_picking.action_validate_picking()), tuple
         )

--- a/stock_barcodes/wizard/__init__.py
+++ b/stock_barcodes/wizard/__init__.py
@@ -1,6 +1,5 @@
 from . import stock_barcodes_read
 from . import stock_barcodes_read_inventory
-from . import stock_barcodes_candidate_picking
 from . import stock_barcodes_read_picking
 from . import stock_barcodes_read_todo
 from . import stock_production_lot

--- a/stock_barcodes/wizard/stock_barcodes_read_picking.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking.py
@@ -17,11 +17,6 @@ class WizStockBarcodesReadPicking(models.TransientModel):
     _inherit = "wiz.stock.barcodes.read"
     _description = "Wizard to read barcode on picking"
 
-    @property
-    @api.depends("picking_mode")
-    def _field_candidate_ids(self):
-        return "candidate_%s_ids" % self.picking_mode
-
     picking_id = fields.Many2one(
         comodel_name="stock.picking", string="Picking", readonly=True
     )
@@ -29,16 +24,6 @@ class WizStockBarcodesReadPicking(models.TransientModel):
     picking_ids = fields.Many2many(
         comodel_name="stock.picking", string="Pickings", readonly=True
     )
-    candidate_picking_id = fields.Many2one(
-        comodel_name="stock.picking", related="candidate_picking_ids.picking_id"
-    )
-    candidate_picking_ids = fields.One2many(
-        comodel_name="wiz.candidate.picking",
-        inverse_name="wiz_barcode_id",
-        string="Candidate pickings",
-        readonly=True,
-    )
-
     picking_product_qty = fields.Float(
         string="Picking quantities", digits="Product Unit of Measure", readonly=True
     )
@@ -178,27 +163,8 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             for rec in self
         ]
 
-    def _set_default_picking(self):
-        picking_id = self.env.context.get("default_picking_id", False)
-        if picking_id:
-            self._set_candidate_pickings(self.env["stock.picking"].browse(picking_id))
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        # When user click any view button the wizard record is create and the
-        # picking candidates have been lost, so we need set it.
-        wizards = super().create(vals_list)
-        for wiz in wizards:
-            if wiz.picking_id:
-                wiz._set_candidate_pickings(wiz.picking_id)
-        return wizards
-
     @api.onchange("picking_id")
     def onchange_picking_id(self):
-        # Add to candidate pickings the default picking. We are in a wizard
-        # view, so for create a candidate picking with the same default picking
-        # we need create it in this onchange
-        self._set_default_picking()
         self.fill_pending_moves()
         self.determine_todo_action()
 
@@ -318,7 +284,6 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         if res:
             move_dic = self.with_context(**self.env.context)._process_stock_move_line()
             if move_dic:
-                self[self._field_candidate_ids].scan_count += 1
                 if self.env.context.get("force_create_move"):
                     self.move_line_ids.barcode_scan_state = "done_forced"
                 if not self.keep_screen_values or self.todo_line_id.state != "pending":
@@ -341,7 +306,8 @@ class WizStockBarcodesReadPicking(models.TransientModel):
                     self.update_keep_values(keep_vals)
             # Force refresh candidate pickings to show green if not pending moves
             if not self.pending_move_ids:
-                self._set_candidate_pickings(self.picking_id)
+                pass
+                # TODO: Make more visible when picking is done
             return move_dic
         return res
 
@@ -409,28 +375,6 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         if self.picking_id:
             domain.append(("picking_id", "=", self.picking_id.id))
         return domain
-
-    def _set_candidate_pickings(self, candidate_pickings):
-        vals = [(5, 0, 0)]
-        vals.extend([(0, 0, {"picking_id": p.id}) for p in candidate_pickings])
-        self.candidate_picking_ids = vals
-
-    def _search_candidate_picking(self, moves_todo=False):
-        if not moves_todo:
-            moves_todo = self.env["stock.move"].search(
-                self._prepare_stock_moves_domain()
-            )
-        if not self.picking_id:
-            candidate_pickings = moves_todo.mapped("picking_id")
-            candidate_pickings_count = len(candidate_pickings)
-            if candidate_pickings_count > 1:
-                self._set_candidate_pickings(candidate_pickings)
-                return False
-            if candidate_pickings_count == 1:
-                self.picking_id = candidate_pickings
-                self._set_candidate_pickings(candidate_pickings)
-            _logger.info("No picking assigned")
-        return True
 
     def _check_guided_restrictions(self):
         # Check restrictions in guided mode
@@ -524,13 +468,6 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             )
         else:
             moves_todo = StockMove.search(domain)
-        try:
-            getattr(
-                self,
-                "_search_candidate_%s" % self.picking_mode,
-            )(moves_todo)
-        except AttributeError:
-            return False
         sml_vals = {}
         candidate_lines = self._get_candidate_stock_move_lines(moves_todo, sml_vals)
         lines = candidate_lines.filtered(
@@ -730,12 +667,6 @@ class WizStockBarcodesReadPicking(models.TransientModel):
     def update_fields_after_process_stock(self, moves):
         self.picking_product_qty = sum(moves.mapped("quantity_done"))
 
-    def _candidate_picking_selected(self):
-        if len(self.candidate_picking_ids) == 1:
-            return self.candidate_picking_ids.picking_id
-        else:
-            return self.env["stock.picking"].browse()
-
     def check_done_conditions(self):
         res = super().check_done_conditions()
         if (
@@ -760,13 +691,7 @@ class WizStockBarcodesReadPicking(models.TransientModel):
         if self.picking_mode == "picking_batch":
             return res
         if not self.picking_id:
-            if not self._search_candidate_picking():
-                self._set_messagge_info(
-                    "info", _("Click on picking pushpin to lock it")
-                )
-                return False
-        if self.picking_id and self.picking_id != self._candidate_picking_selected():
-            self._set_messagge_info("info", _("Click on picking pushpin to lock it"))
+            self._set_messagge_info("info", _("No picking selected"))
             return False
         return res
 
@@ -978,44 +903,33 @@ class WizStockBarcodesReadPicking(models.TransientModel):
             list(todo_vals.values())
         )
 
-    def action_validate_picking(self):
-        # for candidate_picking in self.candidate_picking_ids:
-        valid, result = self.candidate_picking_ids.with_context(
-            wiz_barcode_id=self.id,
-            picking_id=self.picking_id.id,
-            skip_sms=True,
-            skip_immediate=True,
-        ).action_validate_picking()
-        if not valid:
-            return result
-        action = self.env["ir.actions.actions"]._for_xml_id(
-            "stock_barcodes.stock_barcodes_action_picking_tree_ready"
+    def action_open_picking(self):
+        return self.picking_id.with_context(
+            control_panel_hidden=False
+        ).get_formview_action()
+
+    def _get_picking_to_validate(self):
+        """Inject context show_picking_type_action_tree to redirect to picking list
+        after validate picking in barcodes environment.
+        The stock_barcodes_validate_picking key allows to know when a picking has been
+        validated from stock barcodes interface.
+        """
+        return self.picking_id.with_context(
+            show_picking_type_action_tree=True, stock_barcodes_validate_picking=True
         )
 
-        if self.picking_id and self.picking_id.picking_type_id:
-            context = self.env.context.copy()
-            context.update(safe_eval(action["context"]))
-            context.update(
-                {"search_default_picking_type_id": self.picking_id.picking_type_id.id}
+    def action_validate_picking(self):
+        context = dict(self.env.context)
+        picking = self._get_picking_to_validate()
+        if picking._check_immediate():
+            return False, picking.with_context(
+                button_validate_picking_ids=picking.ids, operations_mode=True
+            )._action_generate_immediate_wizard(
+                show_transfers=picking._should_show_transfers()
             )
-            action["context"] = context
-
-        return action
-
-    def action_open_picking(self):
-        for candidate_picking in self.candidate_picking_ids:
-            candidate_picking.with_context(
-                wiz_barcode_id=self.id, picking_id=self.picking_id.id
-            ).action_open_picking()
-
-    def action_unlock_picking(self):
-        for candidate_picking in self.candidate_picking_ids:
-            candidate_picking.with_context(
-                wiz_barcode_id=self.id
-            ).action_unlock_picking()
-
-    def action_lock_picking(self):
-        for candidate_picking in self.candidate_picking_ids:
-            candidate_picking.with_context(
-                wiz_barcode_id=self.id, picking_id=self.picking_id.id
-            ).action_lock_picking()
+        return (
+            True,
+            picking.with_context(
+                skip_sms=context.get("skip_sms", False)
+            ).button_validate(),
+        )

--- a/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_picking_views.xml
@@ -21,79 +21,8 @@
                         invisible="context.get('hide_partner', False)"
                     />]
                 </t>
-                <field name="candidate_picking_id" invisible="1" />
-
-                <button
-                    name="action_unlock_picking"
-                    type="object"
-                    title="unlock picking"
-                    attrs="{'invisible': [('candidate_picking_id', '=', 'picking_id')]}"
-                    class="float-end"
-                >
-                    <span class="fa-stack fa-lg">
-                        <!-- FIXME: Use fa-thumbtack fa-stack-2x on v13 with FA v5.4 -->
-                        <i class="fa fa-thumb-tack fa-stack-1x" />
-                        <!-- FIXME: Use fa-slash on v13 with FA v5.4 -->
-                        <i class="fa fa-ban fa-stack-2x" />
-                    </span>
-                </button>
-                <button
-                    name="action_lock_picking"
-                    type="object"
-                    title="lock picking"
-                    attrs="{'invisible': [('candidate_picking_id', '!=', 'picking_id')]}"
-                    class="fa fa-thumb-tack fa-2x float-end"
-                />
             </xpath>
             <xpath expr="//field[@name='message_type']" position="before">
-                <field
-                    name="candidate_picking_ids"
-                    attrs="{'invisible': [('candidate_picking_ids', '=', [])]}"
-                    mode="kanban"
-                    nolabel="1"
-                    force_save="1"
-                    class="o_x2m_control_panel"
-                    options="{'always_reload': True}"
-                >
-                    <kanban>
-                        <field name="name" />
-                        <field name="partner_id" />
-                        <field name="date" />
-                        <field name="state" />
-                        <field name="picking_id" />
-                        <field name="wiz_picking_id" />
-                        <field name="product_qty_reserved" />
-                        <field name="product_uom_qty" />
-                        <field name="product_qty_done" />
-                        <field name="scan_count" />
-                        <field name="is_pending" />
-                        <field name="note" />
-                        <templates>
-                            <t t-name="kanban-box">
-                                <div
-                                    t-if="!widget.isHtmlEmpty(record.note.raw_value)"
-                                    t-att-class="'oe_kanban_color_alert' + (record.is_pending.raw_value == false ? ' bg-success' : '')"
-                                >
-                                    <div class="oe_kanban_details p-2">
-                                        <field
-                                            name="scan_count"
-                                            invisible="1"
-                                            force_save="1"
-                                        />
-                                        <div
-                                            class="fw-bold text-center text-danger fst-italic"
-                                        >
-                                            <t
-                                                t-out="record.note.value"
-                                                invisible="context.get('hide_note', False)"
-                                            />
-                                        </div>
-                                    </div>
-                                </div>
-                            </t>
-                        </templates>
-                    </kanban>
-                </field>
                 <field
                     name="todo_line_display_ids"
                     mode="kanban"
@@ -276,17 +205,13 @@
                                                     class="d-flex justify-content-start align-items-center indent h4 pt-3"
                                                 >
                                                     <t t-if="record.lot_id.raw_value">
-                                                        Lot:
-                                                        <span
-                                                            t-esc="record.lot_id.raw_value"
-                                                        />
+                                                        Lot: <field name="lot_id" />
                                                     </t>
                                                     <t
                                                         t-if="record.result_package_id.raw_value"
                                                     >
-                                                        Package:
-                                                        <span
-                                                            t-esc="record.result_package_id.raw_value"
+                                                        Package: <field
+                                                            name="result_package_id"
                                                         />
                                                     </t>
                                                 </div>
@@ -294,11 +219,7 @@
                                             <div
                                                 class="col-4 col-md-4 d-flex justify-content-end align-items-center"
                                             >
-                                                <span
-                                                    class="h3"
-                                                    t-esc="record.qty_done.raw_value"
-                                                />
-
+                                                <field class="h3" name="qty_done" />
                                                 <button
                                                     name="action_barcode_detailed_operation_unlink"
                                                     type="object"

--- a/stock_barcodes/wizard/stock_barcodes_read_todo.py
+++ b/stock_barcodes/wizard/stock_barcodes_read_todo.py
@@ -174,6 +174,7 @@ class WizStockBarcodesReadTodo(models.TransientModel):
         for field in self.fields_to_fill_from_pending_line():
             self.wiz_barcode_id[field] = self[field]
         # Force fill product_qty if filled_default is set
+        self.wiz_barcode_id.product_qty = 0.0
         if self.wiz_barcode_id.option_group_id.get_option_value(
             "product_qty", "filled_default"
         ):
@@ -185,12 +186,11 @@ class WizStockBarcodesReadTodo(models.TransientModel):
         self.wiz_barcode_id._set_focus_on_qty_input()
 
     def operation_quantities(self):
+        self.fill_from_pending_line()
         self.wiz_barcode_id.manual_entry = True
         self.wiz_barcode_id.product_qty = self.product_qty_reserved
-        self.wiz_barcode_id.product_id = self.product_id.id
         if self.wiz_barcode_id.picking_id.picking_type_id.code != "incoming":
             self.wiz_barcode_id.qty_available = self.product_qty_reserved
-            self.wiz_barcode_id.product_id = self.product_id.id
             self.wiz_barcode_id.location_id = self.location_id.id
         self.wiz_barcode_id.with_context(manual_picking=True).action_confirm()
 
@@ -206,14 +206,8 @@ class WizStockBarcodesReadTodo(models.TransientModel):
     def action_barcode_inventory_quant_edit(self):
         wiz_barcode_id = self.env.context.get("wiz_barcode_id", False)
         wiz_barcode = self.env["wiz.stock.barcodes.read.picking"].browse(wiz_barcode_id)
-        for quant in self:
-            # Try to assign fields with the same name between quant and the scan wizard
-            for fname in self._get_fields_to_edit():
-                if hasattr(wiz_barcode, fname):
-                    wiz_barcode[fname] = quant[fname]
-            wiz_barcode.product_qty = quant.qty_done
-
         wiz_barcode.manual_entry = True
+        self.fill_from_pending_line()
         self.env["bus.bus"]._sendone(
             "stock_barcodes_scan",
             "stock_barcodes_edit_manual",


### PR DESCRIPTION
cc @Tecnativa

I have decided to remove this feature because it is not used by customers, which means we have less code and it is clearer.

I still have one question to resolve: **what happens when we press the scan button in the kanban view of operation types?**

ping @carlosdauden @edescalona @Christian-RB 