### PR TITLE
[16.0][FIX] stock_barcodes: Restore default behaviour to accumulate qty_done on each scan. Added new option in options model

### DIFF
--- a/stock_barcodes/models/stock_barcodes_option.py
+++ b/stock_barcodes/models/stock_barcodes_option.py
@@ -101,6 +101,9 @@ class StockBarcodesOptionGroup(models.Model):
         ]
     )
     display_read_quant = fields.Boolean(string="Read items on inventory mode")
+    no_increase_qty_done = fields.Boolean(
+        string="Do not increase qty done on each scan",
+    )
 
     def get_option_value(self, field_name, attribute):
         option = self.option_ids.filtered(lambda op: op.field_name == field_name)[:1]

--- a/stock_barcodes/views/stock_barcodes_option_view.xml
+++ b/stock_barcodes/views/stock_barcodes_option_view.xml
@@ -34,6 +34,7 @@
                             <field name="show_detailed_operations" />
                             <field name="auto_put_in_pack" />
                             <field name="display_read_quant" />
+                            <field name="no_increase_qty_done" />
                         </group>
                         <group>
                             <field name="ignore_filled_fields" />

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -761,7 +761,8 @@ class WizStockBarcodesRead(models.AbstractModel):
         context = dict(self.env.context)
         if self._name == "wiz.stock.barcodes.read.picking":
             no_increase_qty_done = (
-                context.get("no_increase_qty_done", False) or self.manual_entry
+                context.get("no_increase_qty_done", False)
+                or self.option_group_id.no_increase_qty_done
             )
             force_create_move = context.get("force_create_move", False)
         res = self.with_context(


### PR DESCRIPTION
cc @Tecnativa 

Please @edescalona You con not change the default behaviour as you want... always you can add an option to options group to modelling it
Maybe now, the context key 'no_increase_qty_done' is not needed.. **Can you confirm it??**

ping @carlosdauden @Christian-RB @edescalona