### PR TITLE
[16.0][IMP] stock_barcodes: Form visibility

### DIFF
--- a/stock_barcodes/models/stock_barcodes_option.py
+++ b/stock_barcodes/models/stock_barcodes_option.py
@@ -104,6 +104,7 @@ class StockBarcodesOptionGroup(models.Model):
     no_increase_qty_done = fields.Boolean(
         string="Do not increase qty done on each scan",
     )
+    show_form_scan = fields.Boolean(default=True)
 
     def get_option_value(self, field_name, attribute):
         option = self.option_ids.filtered(lambda op: op.field_name == field_name)[:1]

--- a/stock_barcodes/static/src/widgets/boolean_toggle.esm.js
+++ b/stock_barcodes/static/src/widgets/boolean_toggle.esm.js
@@ -20,6 +20,8 @@ class BarcodeBooleanToggleField extends BooleanToggleField {
         useBus(this.env.bus, "disableFormEditBarcode", () =>
             this.enableFormEdit(false, true)
         );
+        this.data = this.env.model.root.data;
+        this.show_form_scan = this.data.show_form_scan;
     }
 
     /*
@@ -46,7 +48,7 @@ class BarcodeBooleanToggleField extends BooleanToggleField {
             const $div_inventory_quant_ids = $("div[name='inventory_quant_ids']").find(
                 "div.o_kanban_renderer"
             );
-            if ($form_edit.length > 0) {
+            if ($form_edit.length > 0 && !this.show_form_scan) {
                 if (newValue) {
                     $form_edit.removeClass("d-none");
                     $div_inventory_quant_ids.addClass("inventory_quant_ids_with_form");

--- a/stock_barcodes/tests/test_stock_barcodes.py
+++ b/stock_barcodes/tests/test_stock_barcodes.py
@@ -139,3 +139,12 @@ class TestStockBarcodes(TestCommonStockBarcodes):
                     "context": "{'search_default_code': 'incoming'}  ",
                 }
             )
+
+    def test_compute_show_form_scan(self):
+        option_group_id = self.env["stock.barcodes.option.group"].create(
+            {"name": "Option Group Visibility"}
+        )
+        self.wiz_scan_inv = self.WizScanReadInventory.create(
+            {"option_group_id": option_group_id.id, "step": 1}
+        )
+        self.assertTrue(self.wiz_scan_inv.show_form_scan)

--- a/stock_barcodes/views/stock_barcodes_option_view.xml
+++ b/stock_barcodes/views/stock_barcodes_option_view.xml
@@ -35,6 +35,7 @@
                             <field name="auto_put_in_pack" />
                             <field name="display_read_quant" />
                             <field name="no_increase_qty_done" />
+                            <field name="show_form_scan" />
                         </group>
                         <group>
                             <field name="ignore_filled_fields" />

--- a/stock_barcodes/wizard/stock_barcodes_read.py
+++ b/stock_barcodes/wizard/stock_barcodes_read.py
@@ -97,6 +97,11 @@ class WizStockBarcodesRead(models.AbstractModel):
     )
 
     enable_add_product = fields.Boolean(default=True)
+    show_form_scan = fields.Boolean(compute="_compute_show_form_scan")
+
+    def _compute_show_form_scan(self):
+        for barcode in self:
+            barcode.show_form_scan = barcode.option_group_id.show_form_scan
 
     @api.depends("res_id")
     def _compute_action_ids(self):

--- a/stock_barcodes/wizard/stock_barcodes_read_views.xml
+++ b/stock_barcodes/wizard/stock_barcodes_read_views.xml
@@ -61,15 +61,13 @@
                         <field name="keep_result_package" invisible="1" />
                         <field name="create_lot" invisible="1" />
                         <field name="lot_id" invisible="1" />
+                        <field name="show_form_scan" invisible="1" />
                         <field
                             name="_barcode_scanned"
                             widget="barcode_handler"
                             invisible="0"
                         />
-                        <group
-                            name="scan_fields"
-                            class="bg-light scan_fields p-2 d-none"
-                        >
+                        <group name="scan_fields" class="bg-light scan_fields p-2">
                             <group name="location" col="1">
                                 <div class="mt-1" colspan="2">
                                     <strong class=" d-none d-sm-block">Source Location


### PR DESCRIPTION
@BinhexTeam

Two ways have been added to display or hide the scanning form:

- Visual: A new option for the barcode options; default is True. 
<img width="237" height="48" alt="image" src="https://github.com/user-attachments/assets/0090d492-00d8-4c7c-a909-2d1fe6d5d6e2" />

- Code: A method (`_compute_show_form_scan`) that can be inherited and perform more specific conditions.

ping @sergio-teruel @pedrobaeza @Christian-RB