### PR TITLE
[18.0][FIX] barcodes_generator_abstract: preserve literal N and D in barcode patterns

### DIFF
--- a/barcodes_generator_abstract/models/barcode_generate_mixin.py
+++ b/barcodes_generator_abstract/models/barcode_generate_mixin.py
@@ -4,6 +4,8 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import re
+
 import barcode
 
 from odoo import api, exceptions, fields, models
@@ -86,17 +88,23 @@ class BarcodeGenerateMixin(models.AbstractModel):
         """
         If the pattern is '23.....{NNNDD}'
         this function will return '23.....00000'
+        Only replace N and D inside braces, and remove the braces in the result.
         Note : Overload _get_replacement_char to have another char
         instead that replace 'N' and 'D' char.
         """
         if not item.barcode_rule_id:
             return False
 
-        # Define barcode
-        custom_code = item.barcode_rule_id.pattern
-        custom_code = custom_code.replace("{", "").replace("}", "")
-        custom_code = custom_code.replace("D", self._get_replacement_char("D"))
-        return custom_code.replace("N", self._get_replacement_char("N"))
+        pattern = item.barcode_rule_id.pattern
+
+        def _replace_inside_braces(match):
+            content = match.group(1)
+            content = content.replace("N", self._get_replacement_char("N"))
+            content = content.replace("D", self._get_replacement_char("D"))
+            return content
+
+        custom_code = re.sub(r"\{([^}]*)\}", _replace_inside_braces, pattern)
+        return custom_code
 
     @api.model
     def _get_replacement_char(self, char):

--- a/barcodes_generator_abstract/readme/CONTRIBUTORS.md
+++ b/barcodes_generator_abstract/readme/CONTRIBUTORS.md
@@ -6,3 +6,5 @@
   - Ilyas \<<irazor147@gmail.com>\>
 - [Trobz](https://trobz.com):
   - Khoi (Kien Kim) \<<khoikk@trobz.com>\>
+- [FactorLibre](https://www.factorlibre.com):
+  - Sergio Bustamante Ojeda \<<sergio.bustamante@factorlibre.com>\>

--- a/barcodes_generator_abstract/tests/test_barcodes_generator_abstract.py
+++ b/barcodes_generator_abstract/tests/test_barcodes_generator_abstract.py
@@ -100,3 +100,16 @@ class TestBarcodesGeneratorAbstract(BaseCommon, FakeModelLoader):
         self.user_fake.barcode_rule_id = self.barcode_rule_fake
         self.assertEqual(self.user_fake.barcode_base, 1)
         self.assertEqual(self.user_fake.barcode, "2000001000007")
+
+    def test_get_custom_barcode_preserves_literal_chars(self):
+        self.barcode_rule_fake.pattern = "ABND.....{NNNDD}"
+        self.user_fake.barcode_rule_id = self.barcode_rule_fake
+        custom = self.env["res.users"]._get_custom_barcode(self.user_fake)
+        self.assertTrue(custom.startswith("ABND"))
+        self.assertTrue(custom.endswith("00000"))
+
+    def test_get_custom_barcode_no_braces(self):
+        self.barcode_rule_fake.pattern = "AMZNCC0024670952....."
+        self.user_fake.barcode_rule_id = self.barcode_rule_fake
+        custom = self.env["res.users"]._get_custom_barcode(self.user_fake)
+        self.assertEqual(custom, "AMZNCC0024670952.....")


### PR DESCRIPTION
fw-port from https://github.com/OCA/stock-logistics-barcode/pull/743