### PR TITLE
[IMP] barcode_generator_product_variant: has_missing_barcode archive

### DIFF
--- a/barcode_generator_product_variant/models/product_template.py
+++ b/barcode_generator_product_variant/models/product_template.py
@@ -9,7 +9,7 @@ class ProductTemplate(models.Model):
         store=True,
     )
 
-    @api.depends("product_variant_ids.barcode")
+    @api.depends("product_variant_ids.active", "product_variant_ids.barcode")
     def _compute_has_missing_barcodes(self):
         for product in self:
             product.has_missing_barcodes = bool(


### PR DESCRIPTION
This commit fixes an issue where archiving or unarchiving a variant wouldn't update the `has_missing_barcodes` field on the product template and wouldn't hide or show the related button accordingly