### PR TITLE
[16.0][IMP] stock_barcodes: document configuration and add field help

### DIFF
--- a/stock_barcodes/models/stock_barcodes_action.py
+++ b/stock_barcodes/models/stock_barcodes_action.py
@@ -21,15 +21,32 @@ class StockBarcodesAction(models.Model):
 
     name = fields.Char(translate=True)
     active = fields.Boolean(default=True)
-    sequence = fields.Integer(default=100)
-    action_window_id = fields.Many2one(
-        comodel_name="ir.actions.act_window", string="Action window"
+    sequence = fields.Integer(
+        default=100, help="Order of the tile in the Barcodes menu"
     )
-    context = fields.Char()
+    action_window_id = fields.Many2one(
+        comodel_name="ir.actions.act_window",
+        string="Action window",
+        help="Window action executed when the tile is pressed or its barcode "
+        "is scanned",
+    )
+    context = fields.Char(
+        help="Optional context added to the window action, e.g. "
+        "{'search_default_code': 'incoming'} to open it with a filter of its "
+        "search view already applied.\n"
+        "It must not start or end with a space",
+    )
     key_shortcut = fields.Integer()
     key_char_shortcut = fields.Char()
-    icon_class = fields.Char()
-    barcode = fields.Char()
+    icon_class = fields.Char(
+        help="CSS class of the icon shown on the tile, e.g. a Font Awesome "
+        "class such as fa-truck"
+    )
+    barcode = fields.Char(
+        help="Barcode that triggers this action when scanned from the barcode "
+        "interface. Only letters, digits and dashes, without spaces, and it "
+        "must not be used by another action",
+    )
     barcode_image = fields.Image(
         "Barcode image",
         readonly=True,

--- a/stock_barcodes/models/stock_barcodes_option.py
+++ b/stock_barcodes/models/stock_barcodes_option.py
@@ -8,7 +8,11 @@ class StockBarcodesOptionGroup(models.Model):
     _description = "Options group for barcode interface"
 
     name = fields.Char()
-    code = fields.Char()
+    code = fields.Char(
+        help="Short code of the group. It is not only a label: the interface "
+        "checks it to apply specific behaviors, so keep IN for receipts, OUT "
+        "for deliveries and REL for relocation groups"
+    )
     option_ids = fields.One2many(
         comodel_name="stock.barcodes.option", inverse_name="option_group_id", copy=True
     )
@@ -41,6 +45,8 @@ class StockBarcodesOptionGroup(models.Model):
     )
     ignore_filled_fields = fields.Boolean(
         string="Ignore filled fields",
+        help="If checked, the required fields that already have a value are "
+        "skipped when resolving a scanned barcode, instead of being overwritten",
     )
     auto_put_in_pack = fields.Boolean(
         string="Auto put in pack", help="Auto put in pack before picking validation"
@@ -90,21 +96,41 @@ class StockBarcodesOptionGroup(models.Model):
     )
     display_notification = fields.Boolean(
         string="Display Odoo notifications",
+        help="If checked, the interface messages (barcode not found, required "
+        "field empty, ...) are also shown as Odoo notifications",
     )
     use_location_dest_putaway = fields.Boolean(
         string="Use location dest. putaway",
+        help="If checked, a destination location that is required but still "
+        "empty is computed with the putaway strategy of the transfer "
+        "destination instead of being asked for",
     )
     location_field_to_sort = fields.Selection(
         selection=[
             ("location_id", "Origin Location"),
             ("location_dest_id", "Destination Location"),
-        ]
+        ],
+        help="Location used to sort the movements to process. If not set, the "
+        "destination location is used for incoming and internal transfers, and "
+        "the origin location for the other ones",
     )
-    display_read_quant = fields.Boolean(string="Read items on inventory mode")
+    display_read_quant = fields.Boolean(
+        string="Read items on inventory mode",
+        help="Default value of the Read items switch of the inventory "
+        "interface, which lists either the items already counted or the ones "
+        "that are not counted yet",
+    )
     no_increase_qty_done = fields.Boolean(
         string="Do not increase qty done on each scan",
+        help="If checked, the done quantity of the movement is replaced by "
+        "the quantity of the scan instead of being added to the one already "
+        "registered. Only used in picking operations",
     )
-    show_form_scan = fields.Boolean(default=True)
+    show_form_scan = fields.Boolean(
+        default=True,
+        help="If checked, the scan fields are always displayed. If not, they "
+        "are only displayed while manual entry is enabled",
+    )
 
     def get_option_value(self, field_name, attribute):
         option = self.option_ids.filtered(lambda op: op.field_name == field_name)[:1]
@@ -116,16 +142,60 @@ class StockBarcodesOption(models.Model):
     _description = "Options for barcode interface"
     _order = "step, sequence, id"
 
-    sequence = fields.Integer(default=100)
-    name = fields.Char()
+    sequence = fields.Integer(
+        default=100,
+        help="Order in which the options of a step are evaluated to resolve a "
+        "scanned barcode. The first option that matches wins, so more specific "
+        "fields should come first (a package before a product, for example)",
+    )
+    name = fields.Char(
+        help="Label used for this field in the interface messages, both when "
+        "it asks to scan it and when it reports that it is required"
+    )
     option_group_id = fields.Many2one(
         comodel_name="stock.barcodes.option.group", ondelete="cascade"
     )
-    field_name = fields.Char()
-    filled_default = fields.Boolean()
-    forced = fields.Boolean()
-    to_scan = fields.Boolean()
-    required = fields.Boolean()
-    clean_after_done = fields.Boolean()
+    field_name = fields.Char(
+        help="Technical name of the barcode interface field this option refers "
+        "to, e.g. product_id, lot_id, location_id or product_qty.\n"
+        "A scanned barcode is resolved by calling the process_barcode_<field "
+        "name> method, so a field without such a method will never be filled "
+        "by a scan"
+    )
+    filled_default = fields.Boolean(
+        help="If checked, the field is pre-filled with the value of the "
+        "movement to process each time the interface presents a new one, "
+        "instead of being emptied. When the interface is opened from an "
+        "operation type or a transfer, the locations are pre-filled with its "
+        "default ones.\n"
+        "On the quantity field it also disables the automatic 1 unit per "
+        "scan, leaving the quantity to the user"
+    )
+    forced = fields.Boolean(
+        help="If checked, the value already set in the field prevails: it is "
+        "not overwritten with the location of a scanned lot or package, the "
+        "search for a package is restricted to it, and a detailed operation "
+        "with a different location is not reused.\n"
+        "In guided mode it also rejects a scan whose product, lot or location "
+        "does not match the movement being guided"
+    )
+    to_scan = fields.Boolean(
+        help="If checked, a barcode scanned on this step can fill this field. "
+        "Fields that are not scannable can still be filled manually"
+    )
+    required = fields.Boolean(
+        help="If checked, the movement cannot be processed while the field is "
+        "empty. Required options also drive the navigation: the interface moves "
+        "to the step of the first required option that is still empty"
+    )
+    clean_after_done = fields.Boolean(
+        help="If checked, the field is emptied once the movement is confirmed "
+        "and when the Clean values button is pressed. Leave it unchecked to "
+        "keep the value between scans, as is usually done with the source "
+        "location"
+    )
     message = fields.Char()
-    step = fields.Integer()
+    step = fields.Integer(
+        help="Groups the options into successive screens. Only the options of "
+        "the current step are candidates for the barcode being scanned"
+    )

--- a/stock_barcodes/readme/CONFIGURE.rst
+++ b/stock_barcodes/readme/CONFIGURE.rst
@@ -1,0 +1,139 @@
+The barcode interface is driven entirely by data, not by code: an *option
+group* describes which fields the interface asks for, in which order, and how
+it behaves while scanning. Nothing needs to be configured to try the module
+out — six option groups are installed as demo-free default data — but any real
+deployment will want to review them.
+
+Where the configuration lives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. Go to *Inventory > Configuration > Barcode options* to create or edit
+   option groups.
+#. Go to *Inventory > Configuration > Operation Types*, open an operation type
+   and set:
+
+   * **Barcode option group**: the option group used when the barcode
+     interface is opened for that operation type or for one of its transfers.
+     The *Scan barcodes* button only appears once this field is set.
+   * **New picking barcode option group**: the option group used by the *New*
+     button of the operation type, to create an unplanned picking.
+
+#. Locations need a barcode to be scannable. The *Barcode* field was removed
+   from the location form in Odoo 13.0, so this module adds it back under
+   *Inventory > Configuration > Locations*, in the *Barcode* group.
+
+Option groups delivered by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================= ==== ==============================================
+Name                          Code Intended use
+============================= ==== ==============================================
+Picking IN options            IN   Receipts
+Picking OUT options           OUT  Deliveries (guided mode, manual qty)
+Picking Internal options      INT  Internal transfers
+Picking relocation options    REL  Moving stock between locations
+Inventory options             INV  Inventory adjustments
+Operation options             OPE  Entry point of the *Operations* menu
+============================= ==== ==============================================
+
+These records are created with ``noupdate="1"``, so your changes to them are
+kept across module updates. Copying a group (the ``option_ids`` lines are
+copied too) is usually safer than editing a default one.
+
+Steps to scan
+~~~~~~~~~~~~~
+
+The *Steps to scan* list of an option group is the core of the configuration.
+Each line binds one field of the scan wizard to the scanning workflow:
+
+* **Field name** is the technical name of the wizard field the line refers to
+  (``product_id``, ``lot_id``, ``location_id``, ``location_dest_id``,
+  ``package_id``, ``result_package_id``, ``packaging_id``, ``product_qty``,
+  ``packaging_qty``, ``owner_id``). A scanned barcode is resolved by calling
+  ``process_barcode_<field name>`` on the wizard, so a line whose field name
+  has no such method will never match a barcode.
+* **Step** groups lines into successive screens. The interface is always
+  positioned on one step, and only the lines of the current step are candidates
+  for the barcode being scanned. The current step is recomputed after each scan:
+  it becomes the step of the first *required* line that is still empty.
+* **Sequence** orders the lines inside a step. The interface tries them in that
+  order and stops at the first one that resolves the barcode, so put the most
+  specific field first — for example a package before a product, since a
+  package barcode would otherwise never be reached.
+* **To scan** makes the line a candidate for barcode resolution. Lines that are
+  not *to scan* can still be filled manually or by another line's side effects,
+  but scanning will never assign them. The names of the *to scan* lines of the
+  current step are what the interface displays as *Scan ...*.
+* **Required** prevents the movement from being processed while the field is
+  empty, and is what drives step navigation. ``lot_id`` is skipped when the
+  product is not tracked, or when *Get lots automatically* or *Create lots if
+  not match* apply.
+* **Filled default** pre-fills the field with the value of the movement to
+  process each time the interface presents a new one, instead of emptying it.
+  When the interface is opened from an operation type or a transfer, the
+  locations are pre-filled with its default ones, and in inventory mode the
+  source location comes from the stock location of the first warehouse. For
+  ``product_qty`` it also disables the automatic "1 unit per scan" increment,
+  leaving the quantity to the user.
+* **Forced** makes the value already set in the field prevail. On
+  ``location_id`` it keeps the location entered by the user instead of taking
+  the one of a scanned lot or package, restricts the search for a package to
+  it, and forbids reusing an existing detailed operation that has a different
+  location, so a new one is created instead. In guided mode it additionally
+  rejects a scan whose product, lot or location does not match the movement
+  being guided (*Wrong product*, *Wrong lot*, *Wrong location*).
+* **Clean after done** empties the field once the movement is confirmed. Leave
+  it unchecked for fields that should persist between scans, typically the
+  source location.
+
+As an example, the *Picking OUT options* group is configured as three steps:
+package, product and lot in step 1, the source location in step 2 (pre-filled
+and forced) and the quantity in step 3.
+
+Behavior settings
+~~~~~~~~~~~~~~~~~
+
+The remaining fields of the option group form change how the interface
+behaves. They are documented in the tooltip of each field; the ones worth
+knowing before a first configuration are:
+
+* **Mode**: set it to *Guided* to display the movement that has to be
+  processed and to enable the *Forced* option of the steps.
+* **Manual entry**: opens the interface with manual entry already enabled, so
+  values can be typed instead of scanned. The hardware scanner stays active.
+  **Field to focus on manual entry** decides which field gets the focus then.
+* **Show pending moves** / **Source of pending moves**: display the list of
+  movements left to process, taken either from the detailed operations
+  (``move_line_ids``) or from the operations (``move_ids``). Choose
+  ``move_ids`` together with **Confirmed moves** to work without reservations.
+* **Ignore filled fields**: skip the required fields that already have a value
+  when resolving a barcode, instead of trying to overwrite them.
+* **Group key for todo records**: an expression list used to group the source
+  records into the movements to process, for example
+  ``object.location_id,object.product_id,object.lot_id``.
+* **Accumulate read quantity**: add the scanned quantity to the existing line
+  instead of replacing it — usually what is expected when the same product is
+  scanned several times.
+
+Barcode actions
+~~~~~~~~~~~~~~~
+
+Barcode actions are the tiles of the *Barcodes* menu, and they can be reached
+by scanning a barcode instead of touching the screen. Go to
+*Inventory > Configuration > Barcode Actions* to configure them:
+
+* **Action window** is the window action to execute, and **Context** an
+  optional context added to it, for instance
+  ``{'search_default_code': 'incoming'}`` to open the action with a filter of
+  its search view already applied. The context must not start or end with a
+  space.
+* **Barcode** is the barcode that triggers the action. Letters, digits and
+  dashes only, no spaces, and it must be unique across actions. A printable
+  barcode image is generated from it.
+* **Key char shortcut** has no effect: the kanban template of the menu reads
+  it but never displays it nor binds it to a key handler, and the shortcuts of
+  the interface (F2, F4, F9, F12) are hard coded. **Icon class** is the CSS
+  class of the icon of the tile, typically a Font Awesome one.
+
+Select the actions you want and use the *Print barcodes* button to get a PDF
+of their barcodes, ready to be posted next to the workstation.

--- a/stock_barcodes/readme/CONTRIBUTORS.rst
+++ b/stock_barcodes/readme/CONTRIBUTORS.rst
@@ -23,3 +23,5 @@
 * `Binhex <https://www.binhex.cloud/>`_:
 
   * Edilio Escalona Almira
+
+* Takahiro SUNAGA <t.sunaga@takahii.co>

--- a/stock_barcodes/readme/USAGE.rst
+++ b/stock_barcodes/readme/USAGE.rst
@@ -13,62 +13,62 @@ Option 2: Use the barcode interface inventory directly from the Barcodes applica
   #. Go to *Barcodes*.
   #. Select the *Inventory* option.
 
-    .. image:: ../static/src/img/inventory_barcode_action.png
-       :height: 100
-       :width: 200
-       :alt: Inventory barcode action
+     .. image:: ../static/src/img/inventory_barcode_action.png
+        :height: 100
+        :width: 200
+        :alt: Inventory barcode action
 
   #. Start scanning barcodes.
 
 Actions
-  # Press the *+ Product* button to display the form for the new item.
+  #. Press the *+ Product* button to display the form for the new item.
 
-    .. image:: ../static/src/img/add_product.png
-       :height: 100
-       :width: 200
-       :alt: Add product
+     .. image:: ../static/src/img/add_product.png
+        :height: 100
+        :width: 200
+        :alt: Add product
 
-  # When you select a product, a numeric field is displayed to add the quantity.
+  #. When you select a product, a numeric field is displayed to add the quantity.
 
-    .. image:: ../static/src/img/form_add_product_quantity.png
-       :height: 100
-       :width: 200
-       :alt: Add quantity product
+     .. image:: ../static/src/img/form_add_product_quantity.png
+        :height: 100
+        :width: 200
+        :alt: Add quantity product
 
-  # When you press the button with the trash can icon, the values of the form are reset (except for the location) without closing it.
+  #. When you press the button with the trash can icon, the values of the form are reset (except for the location) without closing it.
 
-    .. image:: ../static/src/img/form_add_product_reset.png
-       :height: 100
-       :width: 200
-       :alt: Reset data form
+     .. image:: ../static/src/img/form_add_product_reset.png
+        :height: 100
+        :width: 200
+        :alt: Reset data form
 
-  # When you press the *Clean values* button, all fields are reset and the form is closed.
-  # When you press the *Confirm* button, the new item is added and the form is closed.
-  # When the eye icon is closed, the created items greater than zero are displayed, and if not, those less than or equal to zero.
+  #. When you press the *Clean values* button, all fields are reset and the form is closed.
+  #. When you press the *Confirm* button, the new item is added and the form is closed.
+  #. When the eye icon is closed, the created items greater than zero are displayed, and if not, those less than or equal to zero.
 
-    .. image:: ../static/src/img/list_items.png
-       :height: 100
-       :width: 200
-       :alt: Reset data form
+     .. image:: ../static/src/img/list_items.png
+        :height: 100
+        :width: 200
+        :alt: Reset data form
 
-  # In the list, the trash can icon allows you to reset the quantity to zero and the edit icon allows you to change the item values.
+  #. In the list, the trash can icon allows you to reset the quantity to zero and the edit icon allows you to change the item values.
 
-    .. image:: ../static/src/img/list_action_items.png
-       :height: 100
-       :width: 200
-       :alt: Reset data form
+     .. image:: ../static/src/img/list_action_items.png
+        :height: 100
+        :width: 200
+        :alt: Reset data form
 
-  # The *Apply* button is only displayed if there are items with quantities greater than zero, regardless of whether they were scanned or entered manually; If you press all the defined quantities will be processed after defining the reason for the inventory adjustment and then the main barcode menu will be displayed.
+  #. The *Apply* button is only displayed if there are items with quantities greater than zero, regardless of whether they were scanned or entered manually; If you press all the defined quantities will be processed after defining the reason for the inventory adjustment and then the main barcode menu will be displayed.
 
-    .. image:: ../static/src/img/apply_inventory.png
-       :height: 100
-       :width: 200
-       :alt: Apply inventory
+     .. image:: ../static/src/img/apply_inventory.png
+        :height: 100
+        :width: 200
+        :alt: Apply inventory
 
-    .. image:: ../static/src/img/apply_inventory_reason.png
-       :height: 100
-       :width: 200
-       :alt: Apply inventory reason
+     .. image:: ../static/src/img/apply_inventory_reason.png
+        :height: 100
+        :width: 200
+        :alt: Apply inventory reason
 
 
 Barcode interface for picking operations
@@ -93,99 +93,99 @@ Option 2: Use the barcode interface picking directly from the Barcodes applicati
   #. Go to *Barcodes*.
   #. Select the option *OPERATIONS*.
 
-    .. image:: ../static/src/img/inventory_barcode_action.png
-       :height: 100
-       :width: 200
-       :alt: Operation barcode action
+     .. image:: ../static/src/img/inventory_barcode_action.png
+        :height: 100
+        :width: 200
+        :alt: Operation barcode action
 
-  # Select the type of picking.
-  # The pickings in ready status are displayed, select the one you want to start scanning.
+  #. Select the type of picking.
+  #. The pickings in ready status are displayed, select the one you want to start scanning.
 
-    .. image:: ../static/src/img/list_picking.png
-       :height: 100
-       :width: 200
-       :alt: List picking
+     .. image:: ../static/src/img/list_picking.png
+        :height: 100
+        :width: 200
+        :alt: List picking
 
   #. Start scanning barcodes.
 
-    .. image:: ../static/src/img/barcode_interface_picking.png
-       :height: 100
-       :width: 200
-       :alt: List picking
+     .. image:: ../static/src/img/barcode_interface_picking.png
+        :height: 100
+        :width: 200
+        :alt: List picking
 
 Actions
-  # All the items that have been configured for the selected picking are listed.
+  #. All the items that have been configured for the selected picking are listed.
 
-    .. image:: ../static/src/img/list_items_picking.png
-       :height: 100
-       :width: 200
-       :alt: List picking
+     .. image:: ../static/src/img/list_items_picking.png
+        :height: 100
+        :width: 200
+        :alt: List picking
 
-  # The edit icon in the list allows you to modify the data.
+  #. The edit icon in the list allows you to modify the data.
 
-    .. image:: ../static/src/img/list_items_picking_edit.png
-       :height: 100
-       :width: 200
-       :alt: Edit picking
+     .. image:: ../static/src/img/list_items_picking_edit.png
+        :height: 100
+        :width: 200
+        :alt: Edit picking
 
-  # The button that contains a *+120* (in this case), allows you to define all the
-    remaining quantities. Once defined, this button disappears and if you want to change the
-    quantities, press the edit button.
+  #. The button that contains a *+120* (in this case), allows you to define all the
+     remaining quantities. Once defined, this button disappears and if you want to change the
+     quantities, press the edit button.
 
-    .. image:: ../static/src/img/list_items_picking_quantity.png
-       :height: 100
-       :width: 200
-       :alt: Quantity picking
+     .. image:: ../static/src/img/list_items_picking_quantity.png
+        :height: 100
+        :width: 200
+        :alt: Quantity picking
 
-  # If there is at least one item with a quantity already defined, an eye icon is displayed,
-    which if closed shows the items and their quantities already scanned.
+  #. If there is at least one item with a quantity already defined, an eye icon is displayed,
+     which if closed shows the items and their quantities already scanned.
 
-    .. image:: ../static/src/img/list_items_picking_scanned.png
-       :height: 100
-       :width: 200
-       :alt: Picking scanned
+     .. image:: ../static/src/img/list_items_picking_scanned.png
+        :height: 100
+        :width: 200
+        :alt: Picking scanned
 
-  # When you press the *Validate* button, a wizard will be displayed to confirm the action.
-    If everything is correct, it is validated and you return to the picking list mentioned above.
+  #. When you press the *Validate* button, a wizard will be displayed to confirm the action.
+     If everything is correct, it is validated and you return to the picking list mentioned above.
 
-    .. image:: ../static/src/img/confirm_items_picking.png
-       :height: 100
-       :width: 200
-       :alt: Picking scanned
+     .. image:: ../static/src/img/confirm_items_picking.png
+        :height: 100
+        :width: 200
+        :alt: Picking scanned
 
-  # If there is an item whose quantity is zero, a wizard will be displayed after the one mentioned
-    above, to confirm if you want to process all the quantities. If positive, you will proceed
-    and be directed to the list mentioned above in the previous point.
+  #. If there is an item whose quantity is zero, a wizard will be displayed after the one mentioned
+     above, to confirm if you want to process all the quantities. If positive, you will proceed
+     and be directed to the list mentioned above in the previous point.
 
-    .. image:: ../static/src/img/confirm_all_quantity_items_picking.png
-       :height: 100
-       :width: 200
-       :alt: Picking scanned
+     .. image:: ../static/src/img/confirm_all_quantity_items_picking.png
+        :height: 100
+        :width: 200
+        :alt: Picking scanned
 
-  # Press the *+ Product* button to display the form for the new item.
+  #. Press the *+ Product* button to display the form for the new item.
 
-    .. image:: ../static/src/img/add_product.png
-       :height: 100
-       :width: 200
-       :alt: Add product
+     .. image:: ../static/src/img/add_product.png
+        :height: 100
+        :width: 200
+        :alt: Add product
 
-  # When you select a product, a numeric field is displayed to add the quantity.
+  #. When you select a product, a numeric field is displayed to add the quantity.
 
-    .. image:: ../static/src/img/form_add_product_quantity.png
-       :height: 100
-       :width: 200
-       :alt: Add quantity product
+     .. image:: ../static/src/img/form_add_product_quantity.png
+        :height: 100
+        :width: 200
+        :alt: Add quantity product
 
-  # When you press the button with the trash can icon, the values of the form are reset (except for the location) without closing it.
+  #. When you press the button with the trash can icon, the values of the form are reset (except for the location) without closing it.
 
-    .. image:: ../static/src/img/form_add_product_reset.png
-       :height: 100
-       :width: 200
-       :alt: Reset data form
+     .. image:: ../static/src/img/form_add_product_reset.png
+        :height: 100
+        :width: 200
+        :alt: Reset data form
 
-  # When you press the *Clean values* button, all fields are reset and the form is closed.
-  # When you press the *Confirm* button, the new item is added and the form is closed.
-  # When adding the new item all the quantities are assigned to it, if you want to modify it, press the edit icon.
+  #. When you press the *Clean values* button, all fields are reset and the form is closed.
+  #. When you press the *Confirm* button, the new item is added and the form is closed.
+  #. When adding the new item all the quantities are assigned to it, if you want to modify it, press the edit icon.
 
 The barcode scanner interface has two operation modes. In both of them user
 can scan:


### PR DESCRIPTION
Closes #757

## Context

The reporter of #757 asked for documentation of the barcode options and actions,
and pointed out that the field helps were not meaningful enough to avoid reading
the source. This PR addresses the configuration side of that request.

`stock_barcodes` is configured entirely through data — an option group describes
which fields the interface asks for, in which order, and how it behaves while
scanning — but nothing in the module explained that.

* The module had no `CONFIGURE` readme fragment, so the generated README jumped
  straight from the installation notes to usage, with no description of the
  option groups, the "Steps to scan" list or the barcode actions.
* The configuration models carried almost no field help. `stock.barcodes.option`
  had none at all on its nine fields, so understanding what *Step*, *Sequence*,
  *To scan*, *Forced* or *Filled default* actually do required reading
  `process_barcode()` in the wizard.

## What this PR does

**`readme/CONFIGURE.rst` (new)**

* Where the configuration lives: *Barcode options*, the two option-group fields
  of an operation type, and the location barcode field this module adds back.
* The six option groups installed as default data, with their code and intended
  use, plus a note that they are `noupdate="1"` and that copying a group is
  safer than editing a default one.
* The meaning of each column of the *Steps to scan* list, including how the
  current step is recomputed after each scan and why the sequence inside a step
  matters, illustrated with the *Picking OUT options* group.
* The behavior settings of an option group that are worth knowing before a first
  configuration, and the barcode actions of the *Barcodes* menu.

**Field help**

Added help to the fields of `stock.barcodes.option`, `stock.barcodes.option.group`
and `stock.barcodes.action` that had none. The help of the option-group `code`
field states explicitly that it is not only a label — `IN`, `OUT` and `REL` are
compared in the wizard to change behavior — since renaming it silently breaks
those branches.

**`readme/USAGE.rst` (fix)**

The items of the two "Actions" blocks used `#` as a list marker instead of the
`#.` expected by reStructuredText, so they rendered as plain paragraphs starting
with a hash instead of numbered steps. The embedded images were also indented
one column short of the item body, which closed the list and turned each of them
into a block quote, restarting the numbering at one on every following item.

## Notes for reviewers

Three fields are left without help **on purpose**, because nothing reads them and
their meaning could not be documented without guessing:

* `stock.barcodes.option.message`
* `stock.barcodes.action.key_shortcut` — neither set nor read anywhere
* `stock.barcodes.action.key_char_shortcut` — the value the kanban template sets
  from it is never used, and the shortcuts of the interface are hard coded

No behavior change: this PR only touches help strings and readme fragments.
